### PR TITLE
feat: GitHub deployment status updates on PRs

### DIFF
--- a/catalog/architecture/deployment.md
+++ b/catalog/architecture/deployment.md
@@ -19,7 +19,7 @@ A single EC2 instance hosts all branch deployments. GitHub push webhooks trigger
 4. **Build and serve** — The script creates/updates a git worktree, runs `bun install && bun run build`, starts/restarts the systemd service, and updates Caddy routing.
 5. **Status updated** — On success, the deployment status is set to `success` with a link to the branch URL. On failure, it is set to `failure`. PRs show a "View deployment" link in the sidebar.
 6. **Traffic routes** — Caddy proxies `/<branch>/` to the branch's Bun process on its assigned port.
-7. **Branch deleted** — When a branch is deleted, the webhook marks its deployment `inactive`.
+7. **Branch deleted** — When a branch is deleted, the webhook marks its deployment as `inactive`.
 
 ## Components
 

--- a/catalog/architecture/deployment.md
+++ b/catalog/architecture/deployment.md
@@ -5,7 +5,7 @@ tags: [infrastructure, deployment, architecture]
 
 # Deployment Architecture
 
-How the forms-lab application is deployed and served.
+How forms-lab is deployed and served.
 
 ## Overview
 

--- a/catalog/architecture/deployment.md
+++ b/catalog/architecture/deployment.md
@@ -15,9 +15,11 @@ A single EC2 instance hosts all branch deployments. GitHub push webhooks trigger
 
 1. **Push to GitHub** — A developer pushes to any branch.
 2. **Webhook fires** — GitHub sends a push event to the webhook listener on EC2.
-3. **Deploy script runs** — The listener validates the signature and spawns the deploy script.
+3. **Deploy script runs** — The listener validates the signature, creates a GitHub Deployment (status: `in_progress`), and spawns the deploy script.
 4. **Build and serve** — The script creates/updates a git worktree, runs `bun install && bun run build`, starts/restarts the systemd service, and updates Caddy routing.
-5. **Traffic routes** — Caddy proxies `/<branch>/` to the branch's Bun process on its assigned port.
+5. **Status updated** — On success, the deployment status is set to `success` with a link to the branch URL. On failure, it is set to `failure`. PRs show a "View deployment" link in the sidebar.
+6. **Traffic routes** — Caddy proxies `/<branch>/` to the branch's Bun process on its assigned port.
+7. **Branch deleted** — When a branch is deleted, the webhook marks its deployment `inactive`.
 
 ## Components
 

--- a/infrastructure/nixos/configuration.nix
+++ b/infrastructure/nixos/configuration.nix
@@ -54,6 +54,9 @@
     secrets.github-webhook-secret = {
       owner = "forms-lab";
     };
+    secrets.github-token = {
+      owner = "forms-lab";
+    };
   };
 
   # Allow forms-lab user to manage its own services and reload Caddy

--- a/infrastructure/nixos/modules/webhook.nix
+++ b/infrastructure/nixos/modules/webhook.nix
@@ -21,6 +21,8 @@
     # script sets ExecStart to a wrapper that reads the secret into an env var.
     script = ''
       export GITHUB_WEBHOOK_SECRET=$(cat ${config.sops.secrets.github-webhook-secret.path})
+      export GITHUB_TOKEN=$(cat ${config.sops.secrets.github-token.path})
+      export DEPLOY_HOSTNAME=ec2-34-197-222-16.compute-1.amazonaws.com
       export PORT=9000
       export DEPLOY_SCRIPT=/srv/forms-lab/deploy.sh
       exec ${pkgs.bun}/bin/bun run /srv/forms-lab/main/src/webhook/main.ts

--- a/infrastructure/nixos/secrets.yaml
+++ b/infrastructure/nixos/secrets.yaml
@@ -1,4 +1,5 @@
 github-webhook-secret: ENC[AES256_GCM,data:XGrQMWleGy5YlOP2a4pQWdu4g+swDtHq+GG4/s1eovbUigorp49hp34ysP7l5zEnvuLBz9vwUvxMjVRuJhW6jg==,iv:QJxWZ6KWOGAO684/gUKHi+LxPd1M2WoqtsdNs8/Kfuk=,tag:znpUJdnJOLaQU2CDA9T/Zw==,type:str]
+github-token: ENC[AES256_GCM,data:IvKFLbpZn70rOLRaYdxG1WVes7dqFSYf3LiUZUrRoFdjD/3nOJLdlX0mH8QJwplhETEBNla1fKPPAOXsRgrXX7tdu72NRTgyWi9sR1TT+cLyoLPV4rFENdrSJUHt,iv:myRp7BKzVzzmFdDd0xF5V4I7QxdbBE8tkfFVRXG1npg=,tag:z5RuJl8yJFKqMn/MWB/1zw==,type:str]
 sops:
     age:
         - recipient: age1u7jjhjuhj9nuzdxygdjrv80z6xvea7pq73jezpqm2xl4s6ty2ajstyyfth
@@ -10,7 +11,7 @@ sops:
             OTZEZVYvSFlrbS9JTEhJam8rUi9sbXMKRtpBQvLDRXgiwQwjQj4SQZLlh6/cikIe
             tJylsePrwgBP3eVMTvhnVhGnmiOjI5HRgDHTfyQ7v2moNFty/4/ZAA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-09T06:42:42Z"
-    mac: ENC[AES256_GCM,data:nklUdUPuxG+d9n2ugPqSP8xhg4RZCwBMXn5QdXrZJQFNFWq5U5Eqyqy+Hz/OjGAByjkhl4KdGt1XcpCojGjUnVeB3MVkVfKZ4o7cEM+W9T/gknOCVyyexPvc3w4H1aaKI83p/lEs63Sd+IdCsfzjDyKOS632txXBI+TXKD7z7lE=,iv:Jv4aP+fnxFxNN84ouHIcp6M83nr9YGun/l2U7htNchg=,tag:8TxXXO+6ckl4XurkbUIfeg==,type:str]
+    lastmodified: "2026-04-10T00:30:48Z"
+    mac: ENC[AES256_GCM,data:K4TpMqB4i3FYoNyZAXYmFZ9nj2Hnq33TzpcntOd412A1Mm2i5joczALfll+js1Ho62nRk6TIHPjM0yu+AUg9kQ4oIpBwO6SArc1fFzLfE9KxYjAfAlw3bZeEEUzAcm/PPumSnPcDYlif+cOXs0Q9XGdHXn0JDjzEAr5dtHOTqSs=,iv:/mk40q1u3b47pVM0Sazv9rtVRSw9q/eFYZiW+hPF+No=,tag:SrTLvz3U6h4DKeWpXUU6sg==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.11.0
+    version: 3.12.2

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -18,6 +18,19 @@ export interface GitHubPullRequest {
   }
 }
 
+export interface GitHubDeployment {
+  id: number
+  url: string
+}
+
+export type DeploymentState =
+  | 'pending'
+  | 'in_progress'
+  | 'success'
+  | 'failure'
+  | 'error'
+  | 'inactive'
+
 export interface GitHubClient {
   listIssues(
     owner: string,
@@ -29,6 +42,21 @@ export interface GitHubClient {
     repo: string,
     branch: string,
   ): Promise<GitHubPullRequest | null>
+  createDeployment(
+    owner: string,
+    repo: string,
+    ref: string,
+    environment: string,
+    description?: string,
+  ): Promise<GitHubDeployment>
+  createDeploymentStatus(
+    owner: string,
+    repo: string,
+    deploymentId: number,
+    state: DeploymentState,
+    environmentUrl?: string,
+    description?: string,
+  ): Promise<void>
 }
 
 export function createGitHubClient(token?: string): GitHubClient {
@@ -70,6 +98,67 @@ export function createGitHubClient(token?: string): GitHubClient {
         return prs.length > 0 ? prs[0] : null
       } catch {
         return null
+      }
+    },
+
+    async createDeployment(owner, repo, ref, environment, description) {
+      const url = `https://api.github.com/repos/${owner}/${repo}/deployments`
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          Accept: 'application/vnd.github+json',
+          'Content-Type': 'application/json',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({
+          ref,
+          environment,
+          description: description || `Deploy ${ref} to ${environment}`,
+          auto_merge: false,
+          required_contexts: [],
+        }),
+      })
+
+      if (!res.ok) {
+        const body = await res.text()
+        throw new Error(
+          `Failed to create deployment: ${res.status} ${res.statusText} — ${body}`,
+        )
+      }
+
+      const data = (await res.json()) as { id: number; url: string }
+      return { id: data.id, url: data.url }
+    },
+
+    async createDeploymentStatus(
+      owner,
+      repo,
+      deploymentId,
+      state,
+      environmentUrl,
+      description,
+    ) {
+      const url = `https://api.github.com/repos/${owner}/${repo}/deployments/${deploymentId}/statuses`
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          Accept: 'application/vnd.github+json',
+          'Content-Type': 'application/json',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({
+          state,
+          auto_inactive: true,
+          ...(environmentUrl ? { environment_url: environmentUrl } : {}),
+          ...(description ? { description } : {}),
+        }),
+      })
+
+      if (!res.ok) {
+        const body = await res.text()
+        throw new Error(
+          `Failed to create deployment status: ${res.status} ${res.statusText} — ${body}`,
+        )
       }
     },
   }

--- a/src/webhook/deploy.ts
+++ b/src/webhook/deploy.ts
@@ -1,3 +1,5 @@
+import type { GitHubClient } from '../services/github'
+
 export interface DeployResult {
   success: boolean
   error?: string
@@ -35,4 +37,80 @@ export async function triggerDeploy(
     console.error(`Deploy error for ${branch}@${sha}:`, message)
     return { success: false, error: message }
   }
+}
+
+export interface DeployWithStatusOptions {
+  branch: string
+  sha: string
+  owner: string
+  repo: string
+  githubClient?: GitHubClient
+  hostname?: string
+}
+
+export async function triggerDeployWithStatus(
+  options: DeployWithStatusOptions,
+): Promise<DeployResult> {
+  const { branch, sha, owner, repo, githubClient, hostname } = options
+  const safeBranch = branch.replace(/\//g, '-')
+
+  if (!githubClient || !owner || !repo) {
+    return triggerDeploy(branch, sha)
+  }
+
+  let deploymentId: number | undefined
+  try {
+    const deployment = await githubClient.createDeployment(
+      owner,
+      repo,
+      sha,
+      safeBranch,
+      `Deploy ${branch} to ${safeBranch}`,
+    )
+    deploymentId = deployment.id
+
+    await githubClient.createDeploymentStatus(
+      owner,
+      repo,
+      deploymentId,
+      'in_progress',
+      undefined,
+      `Deploying ${branch}@${sha.slice(0, 7)}...`,
+    )
+  } catch (err) {
+    console.error('Failed to create GitHub deployment:', err)
+  }
+
+  const result = await triggerDeploy(branch, sha)
+
+  if (deploymentId) {
+    try {
+      if (result.success) {
+        const environmentUrl = hostname
+          ? `https://${hostname}/${safeBranch}/`
+          : undefined
+        await githubClient.createDeploymentStatus(
+          owner,
+          repo,
+          deploymentId,
+          'success',
+          environmentUrl,
+          `Deployed ${branch}@${sha.slice(0, 7)}`,
+        )
+      } else {
+        await githubClient.createDeploymentStatus(
+          owner,
+          repo,
+          deploymentId,
+          'failure',
+          undefined,
+          result.error?.slice(0, 140) || 'Deploy failed',
+        )
+      }
+    } catch (err) {
+      console.error('Failed to update GitHub deployment status:', err)
+    }
+  }
+
+  return result
 }

--- a/src/webhook/handler.ts
+++ b/src/webhook/handler.ts
@@ -3,6 +3,8 @@ import { timingSafeEqual } from 'node:crypto'
 export interface PushEvent {
   branch: string
   sha: string
+  owner: string
+  repo: string
 }
 
 export async function verifySignature(
@@ -24,11 +26,37 @@ export interface PushPayload {
   ref: string
   after: string
   deleted: boolean
+  repository?: {
+    full_name: string
+  }
+}
+
+export interface DeleteEvent {
+  branch: string
+  owner: string
+  repo: string
 }
 
 export function parsePushEvent(payload: PushPayload): PushEvent | null {
   if (payload.deleted) return null
   if (!payload.ref.startsWith('refs/heads/')) return null
   const branch = payload.ref.slice('refs/heads/'.length)
-  return { branch, sha: payload.after }
+  const [owner, repo] = parseRepoFullName(payload.repository?.full_name)
+  return { branch, sha: payload.after, owner, repo }
+}
+
+export function parseDeleteEvent(payload: PushPayload): DeleteEvent | null {
+  if (!payload.deleted) return null
+  if (!payload.ref.startsWith('refs/heads/')) return null
+  const branch = payload.ref.slice('refs/heads/'.length)
+  const [owner, repo] = parseRepoFullName(payload.repository?.full_name)
+  return { branch, owner, repo }
+}
+
+function parseRepoFullName(fullName: string | undefined): [string, string] {
+  if (fullName?.includes('/')) {
+    const [owner, repo] = fullName.split('/')
+    return [owner, repo]
+  }
+  return ['', '']
 }

--- a/src/webhook/main.ts
+++ b/src/webhook/main.ts
@@ -1,7 +1,8 @@
 import { Hono } from 'hono'
-import { triggerDeploy } from './deploy'
+import { createGitHubClient } from '../services/github'
+import { triggerDeployWithStatus } from './deploy'
 import type { PushPayload } from './handler'
-import { parsePushEvent, verifySignature } from './handler'
+import { parseDeleteEvent, parsePushEvent, verifySignature } from './handler'
 
 const app = new Hono()
 
@@ -9,6 +10,16 @@ const secret = process.env.GITHUB_WEBHOOK_SECRET
 if (!secret) {
   console.error('GITHUB_WEBHOOK_SECRET environment variable is required')
   process.exit(1)
+}
+
+const githubToken = process.env.GITHUB_TOKEN
+const githubClient = githubToken ? createGitHubClient(githubToken) : undefined
+const hostname = process.env.DEPLOY_HOSTNAME
+
+if (!githubToken) {
+  console.warn(
+    'GITHUB_TOKEN not set — deployment status updates will be skipped',
+  )
 }
 
 app.get('/health', (c) => {
@@ -36,18 +47,77 @@ app.post('/', async (c) => {
     console.error('Invalid JSON in webhook payload:', err)
     return c.json({ error: 'Invalid JSON' }, 400)
   }
-  const push = parsePushEvent(payload)
-  if (!push) {
-    return c.json({ ignored: true, reason: 'Deleted branch or tag push' }, 200)
+
+  // Handle branch deletion
+  const deletion = parseDeleteEvent(payload)
+  if (deletion) {
+    if (githubClient && deletion.owner && deletion.repo) {
+      markDeploymentInactive(
+        deletion.owner,
+        deletion.repo,
+        deletion.branch,
+      ).catch((err) => {
+        console.error('Failed to mark deployment inactive:', err)
+      })
+    }
+    return c.json(
+      { accepted: true, branch: deletion.branch, action: 'delete' },
+      202,
+    )
   }
 
-  // Trigger deploy asynchronously
-  triggerDeploy(push.branch, push.sha).catch((err) => {
+  const push = parsePushEvent(payload)
+  if (!push) {
+    return c.json({ ignored: true, reason: 'Tag push' }, 200)
+  }
+
+  // Trigger deploy asynchronously with status updates
+  triggerDeployWithStatus({
+    branch: push.branch,
+    sha: push.sha,
+    owner: push.owner,
+    repo: push.repo,
+    githubClient,
+    hostname,
+  }).catch((err) => {
     console.error('Deploy trigger failed:', err)
   })
 
   return c.json({ accepted: true, branch: push.branch, sha: push.sha }, 202)
 })
+
+async function markDeploymentInactive(
+  owner: string,
+  repo: string,
+  branch: string,
+): Promise<void> {
+  if (!githubClient) return
+  const safeBranch = branch.replace(/\//g, '-')
+
+  // List deployments for this environment and mark the latest inactive
+  const url = `https://api.github.com/repos/${owner}/${repo}/deployments?environment=${encodeURIComponent(safeBranch)}&per_page=1`
+  const res = await fetch(url, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${githubToken}`,
+    },
+  })
+
+  if (!res.ok) return
+
+  const deployments = (await res.json()) as Array<{ id: number }>
+  if (deployments.length === 0) return
+
+  await githubClient.createDeploymentStatus(
+    owner,
+    repo,
+    deployments[0].id,
+    'inactive',
+    undefined,
+    `Branch ${branch} deleted`,
+  )
+  console.log(`Marked deployment for ${branch} as inactive`)
+}
 
 const port = process.env.PORT || 9000
 console.log(`Webhook listener running on port ${port}`)

--- a/test/github-deployment.test.ts
+++ b/test/github-deployment.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+import { createGitHubClient } from '../src/services/github'
+
+describe('createDeployment', () => {
+  const originalFetch = globalThis.fetch
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('sends correct POST request to create a deployment', async () => {
+    let capturedUrl = ''
+    let capturedInit: RequestInit | undefined
+    globalThis.fetch = mock(async (url: string, init?: RequestInit) => {
+      capturedUrl = url
+      capturedInit = init
+      return new Response(
+        JSON.stringify({
+          id: 99,
+          url: 'https://api.github.com/repos/flexion/forms-lab/deployments/99',
+        }),
+        {
+          status: 201,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      )
+    }) as unknown as typeof fetch
+
+    const client = createGitHubClient('test-token')
+    const result = await client.createDeployment(
+      'flexion',
+      'forms-lab',
+      'abc123',
+      'feature-branch',
+      'Test deployment',
+    )
+
+    expect(capturedUrl).toBe(
+      'https://api.github.com/repos/flexion/forms-lab/deployments',
+    )
+    expect(capturedInit?.method).toBe('POST')
+
+    const headers = capturedInit?.headers as Record<string, string>
+    expect(headers.Authorization).toBe('Bearer test-token')
+    expect(headers.Accept).toBe('application/vnd.github+json')
+
+    const body = JSON.parse(capturedInit?.body as string)
+    expect(body.ref).toBe('abc123')
+    expect(body.environment).toBe('feature-branch')
+    expect(body.auto_merge).toBe(false)
+    expect(body.required_contexts).toEqual([])
+    expect(body.description).toBe('Test deployment')
+
+    expect(result.id).toBe(99)
+  })
+
+  it('throws on non-ok response', async () => {
+    globalThis.fetch = mock(async () => {
+      return new Response('Not Found', { status: 404, statusText: 'Not Found' })
+    }) as unknown as typeof fetch
+
+    const client = createGitHubClient('test-token')
+    expect(
+      client.createDeployment('flexion', 'forms-lab', 'abc123', 'env'),
+    ).rejects.toThrow('Failed to create deployment: 404 Not Found')
+  })
+
+  it('works without token (no Authorization header)', async () => {
+    let capturedInit: RequestInit | undefined
+    globalThis.fetch = mock(async (_url: string, init?: RequestInit) => {
+      capturedInit = init
+      return new Response(JSON.stringify({ id: 1, url: 'u' }), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }) as unknown as typeof fetch
+
+    const client = createGitHubClient()
+    await client.createDeployment('o', 'r', 'sha', 'env')
+
+    const headers = capturedInit?.headers as Record<string, string>
+    expect(headers.Authorization).toBeUndefined()
+  })
+})
+
+describe('createDeploymentStatus', () => {
+  const originalFetch = globalThis.fetch
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('sends correct POST request to create a deployment status', async () => {
+    let capturedUrl = ''
+    let capturedInit: RequestInit | undefined
+    globalThis.fetch = mock(async (url: string, init?: RequestInit) => {
+      capturedUrl = url
+      capturedInit = init
+      return new Response(JSON.stringify({ id: 1 }), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }) as unknown as typeof fetch
+
+    const client = createGitHubClient('test-token')
+    await client.createDeploymentStatus(
+      'flexion',
+      'forms-lab',
+      99,
+      'success',
+      'https://example.com/branch/',
+      'Deployed successfully',
+    )
+
+    expect(capturedUrl).toBe(
+      'https://api.github.com/repos/flexion/forms-lab/deployments/99/statuses',
+    )
+    expect(capturedInit?.method).toBe('POST')
+
+    const body = JSON.parse(capturedInit?.body as string)
+    expect(body.state).toBe('success')
+    expect(body.auto_inactive).toBe(true)
+    expect(body.environment_url).toBe('https://example.com/branch/')
+    expect(body.description).toBe('Deployed successfully')
+  })
+
+  it('omits environment_url when not provided', async () => {
+    let capturedInit: RequestInit | undefined
+    globalThis.fetch = mock(async (_url: string, init?: RequestInit) => {
+      capturedInit = init
+      return new Response(JSON.stringify({ id: 1 }), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }) as unknown as typeof fetch
+
+    const client = createGitHubClient('test-token')
+    await client.createDeploymentStatus('o', 'r', 1, 'in_progress')
+
+    const body = JSON.parse(capturedInit?.body as string)
+    expect(body.environment_url).toBeUndefined()
+    expect(body.description).toBeUndefined()
+  })
+
+  it('throws on non-ok response', async () => {
+    globalThis.fetch = mock(async () => {
+      return new Response('Forbidden', { status: 403, statusText: 'Forbidden' })
+    }) as unknown as typeof fetch
+
+    const client = createGitHubClient('test-token')
+    expect(
+      client.createDeploymentStatus('o', 'r', 1, 'success'),
+    ).rejects.toThrow('Failed to create deployment status: 403 Forbidden')
+  })
+})

--- a/test/webhook-deploy.test.ts
+++ b/test/webhook-deploy.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from 'bun:test'
-import { triggerDeploy } from '../src/webhook/deploy'
+import type { GitHubClient } from '../src/services/github'
+import { triggerDeploy, triggerDeployWithStatus } from '../src/webhook/deploy'
 
 describe('triggerDeploy', () => {
   const _originalEnv = process.env.DEPLOY_SCRIPT
@@ -60,5 +61,155 @@ describe('triggerDeploy', () => {
     expect(typeof result.error === 'string' || result.error === undefined).toBe(
       true,
     )
+  })
+})
+
+function createMockGitHubClient(): GitHubClient & {
+  calls: Array<{ method: string; args: unknown[] }>
+} {
+  const calls: Array<{ method: string; args: unknown[] }> = []
+  return {
+    calls,
+    async listIssues(...args) {
+      calls.push({ method: 'listIssues', args })
+      return []
+    },
+    async findPullRequest(...args) {
+      calls.push({ method: 'findPullRequest', args })
+      return null
+    },
+    async createDeployment(...args) {
+      calls.push({ method: 'createDeployment', args })
+      return { id: 42, url: 'https://api.github.com/repos/o/r/deployments/42' }
+    },
+    async createDeploymentStatus(...args) {
+      calls.push({ method: 'createDeploymentStatus', args })
+    },
+  }
+}
+
+describe('triggerDeployWithStatus', () => {
+  beforeEach(() => {
+    process.env.DEPLOY_SCRIPT = 'echo'
+  })
+
+  it('creates deployment and sets in_progress then success on successful deploy', async () => {
+    const client = createMockGitHubClient()
+
+    const result = await triggerDeployWithStatus({
+      branch: 'feature/test',
+      sha: 'abc123def456',
+      owner: 'flexion',
+      repo: 'forms-lab',
+      githubClient: client,
+      hostname: 'example.com',
+    })
+
+    expect(result.success).toBe(true)
+
+    const deploymentCalls = client.calls.filter(
+      (c) => c.method === 'createDeployment',
+    )
+    expect(deploymentCalls).toHaveLength(1)
+    expect(deploymentCalls[0].args).toEqual([
+      'flexion',
+      'forms-lab',
+      'abc123def456',
+      'feature-test',
+      'Deploy feature/test to feature-test',
+    ])
+
+    const statusCalls = client.calls.filter(
+      (c) => c.method === 'createDeploymentStatus',
+    )
+    expect(statusCalls).toHaveLength(2)
+    // First call: in_progress
+    expect(statusCalls[0].args[3]).toBe('in_progress')
+    // Second call: success with environment URL
+    expect(statusCalls[1].args[3]).toBe('success')
+    expect(statusCalls[1].args[4]).toBe('https://example.com/feature-test/')
+  })
+
+  it('sets failure status when deploy fails', async () => {
+    process.env.DEPLOY_SCRIPT = 'false'
+    const client = createMockGitHubClient()
+
+    const result = await triggerDeployWithStatus({
+      branch: 'main',
+      sha: 'abc123',
+      owner: 'flexion',
+      repo: 'forms-lab',
+      githubClient: client,
+    })
+
+    expect(result.success).toBe(false)
+
+    const statusCalls = client.calls.filter(
+      (c) => c.method === 'createDeploymentStatus',
+    )
+    expect(statusCalls).toHaveLength(2)
+    expect(statusCalls[0].args[3]).toBe('in_progress')
+    expect(statusCalls[1].args[3]).toBe('failure')
+  })
+
+  it('falls back to plain deploy when no github client provided', async () => {
+    const result = await triggerDeployWithStatus({
+      branch: 'main',
+      sha: 'abc123',
+      owner: 'flexion',
+      repo: 'forms-lab',
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('falls back to plain deploy when owner/repo are empty', async () => {
+    const client = createMockGitHubClient()
+
+    const result = await triggerDeployWithStatus({
+      branch: 'main',
+      sha: 'abc123',
+      owner: '',
+      repo: '',
+      githubClient: client,
+    })
+
+    expect(result.success).toBe(true)
+    expect(client.calls).toHaveLength(0)
+  })
+
+  it('still deploys when GitHub API errors on deployment creation', async () => {
+    const client = createMockGitHubClient()
+    client.createDeployment = async () => {
+      throw new Error('API rate limit')
+    }
+
+    const result = await triggerDeployWithStatus({
+      branch: 'main',
+      sha: 'abc123',
+      owner: 'flexion',
+      repo: 'forms-lab',
+      githubClient: client,
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('omits environment_url when no hostname provided', async () => {
+    const client = createMockGitHubClient()
+
+    await triggerDeployWithStatus({
+      branch: 'main',
+      sha: 'abc123',
+      owner: 'flexion',
+      repo: 'forms-lab',
+      githubClient: client,
+    })
+
+    const statusCalls = client.calls.filter(
+      (c) => c.method === 'createDeploymentStatus',
+    )
+    const successCall = statusCalls.find((c) => c.args[3] === 'success')
+    expect(successCall?.args[4]).toBeUndefined()
   })
 })

--- a/test/webhook-handler.test.ts
+++ b/test/webhook-handler.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'bun:test'
-import { parsePushEvent, verifySignature } from '../src/webhook/handler'
+import {
+  parseDeleteEvent,
+  parsePushEvent,
+  verifySignature,
+} from '../src/webhook/handler'
 
 describe('verifySignature', () => {
   const secret = 'test-secret'
@@ -34,14 +38,20 @@ describe('verifySignature', () => {
 })
 
 describe('parsePushEvent', () => {
-  it('extracts branch name and SHA from push payload', () => {
+  it('extracts branch name, SHA, and repo info from push payload', () => {
     const payload = {
       ref: 'refs/heads/main',
       after: 'abc123def456',
       deleted: false,
+      repository: { full_name: 'flexion/forms-lab' },
     }
     const result = parsePushEvent(payload)
-    expect(result).toEqual({ branch: 'main', sha: 'abc123def456' })
+    expect(result).toEqual({
+      branch: 'main',
+      sha: 'abc123def456',
+      owner: 'flexion',
+      repo: 'forms-lab',
+    })
   })
 
   it('extracts branch with slashes in name', () => {
@@ -49,9 +59,15 @@ describe('parsePushEvent', () => {
       ref: 'refs/heads/slice-0/skeleton',
       after: 'xyz789',
       deleted: false,
+      repository: { full_name: 'flexion/forms-lab' },
     }
     const result = parsePushEvent(payload)
-    expect(result).toEqual({ branch: 'slice-0/skeleton', sha: 'xyz789' })
+    expect(result).toEqual({
+      branch: 'slice-0/skeleton',
+      sha: 'xyz789',
+      owner: 'flexion',
+      repo: 'forms-lab',
+    })
   })
 
   it('returns null for deleted branch', () => {
@@ -71,6 +87,58 @@ describe('parsePushEvent', () => {
       deleted: false,
     }
     const result = parsePushEvent(payload)
+    expect(result).toBeNull()
+  })
+
+  it('handles missing repository field', () => {
+    const payload = {
+      ref: 'refs/heads/main',
+      after: 'abc123',
+      deleted: false,
+    }
+    const result = parsePushEvent(payload)
+    expect(result).toEqual({
+      branch: 'main',
+      sha: 'abc123',
+      owner: '',
+      repo: '',
+    })
+  })
+})
+
+describe('parseDeleteEvent', () => {
+  it('extracts branch and repo info from delete payload', () => {
+    const payload = {
+      ref: 'refs/heads/feature/test',
+      after: '0000000000000000000000000000000000000000',
+      deleted: true,
+      repository: { full_name: 'flexion/forms-lab' },
+    }
+    const result = parseDeleteEvent(payload)
+    expect(result).toEqual({
+      branch: 'feature/test',
+      owner: 'flexion',
+      repo: 'forms-lab',
+    })
+  })
+
+  it('returns null for non-deleted push', () => {
+    const payload = {
+      ref: 'refs/heads/main',
+      after: 'abc123',
+      deleted: false,
+    }
+    const result = parseDeleteEvent(payload)
+    expect(result).toBeNull()
+  })
+
+  it('returns null for tag deletion', () => {
+    const payload = {
+      ref: 'refs/tags/v1.0.0',
+      after: '0000000',
+      deleted: true,
+    }
+    const result = parseDeleteEvent(payload)
     expect(result).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary

Continues #1 — adds GitHub Deployment Status API integration to the webhook so PRs show a "View deployment" link in the sidebar.

- Creates a GitHub Deployment on each push, with status lifecycle: `in_progress` → `success`/`failure`
- Marks deployments `inactive` on branch deletion
- Gracefully degrades when `GITHUB_TOKEN` is not set (deploys still work, no status updates)
- Adds `github-token` sops secret to NixOS config

## Files changed

- `src/services/github.ts` — `createDeployment()` and `createDeploymentStatus()` methods
- `src/webhook/deploy.ts` — `triggerDeployWithStatus()` wrapper
- `src/webhook/handler.ts` — parse repo owner/name from payload, `parseDeleteEvent()`
- `src/webhook/main.ts` — wire up deployment status lifecycle
- `infrastructure/nixos/` — add `github-token` secret and `DEPLOY_HOSTNAME` env var

## Test plan

- [x] All 79 unit tests pass (`bun test`)
- [x] Type check passes (`tsc --noEmit`)
- [x] Biome lint clean
- [x] Deploy this branch to EC2, push a commit, verify "Deployments" section appears on PR