### PR TITLE
infra(bedrock): add IAM instance profile for Bedrock access

### DIFF
--- a/infrastructure/nixos/modules/deploy.nix
+++ b/infrastructure/nixos/modules/deploy.nix
@@ -73,6 +73,7 @@ GITHUB_CLIENT_ID=$(cat /run/secrets/github-client-id 2>/dev/null || echo "")
 GITHUB_CLIENT_SECRET=$(cat /run/secrets/github-client-secret 2>/dev/null || echo "")
 SESSION_SECRET=$(cat /run/secrets/session-secret 2>/dev/null || echo "")
 GITHUB_AUTHZ_ORG=flexion
+AWS_REGION=us-east-1
 ENVEOF
 
     # Start or restart the service (use full path to sudo wrapper with setuid bit)

--- a/infrastructure/pulumi/index.ts
+++ b/infrastructure/pulumi/index.ts
@@ -58,12 +58,46 @@ const sg = new aws.ec2.SecurityGroup('forms-lab-sg', {
   ],
 })
 
+// IAM role for EC2 instance (Bedrock access)
+const role = new aws.iam.Role('forms-lab-role', {
+  assumeRolePolicy: JSON.stringify({
+    Version: '2012-10-17',
+    Statement: [
+      {
+        Effect: 'Allow',
+        Principal: { Service: 'ec2.amazonaws.com' },
+        Action: 'sts:AssumeRole',
+      },
+    ],
+  }),
+  tags: { Name: 'forms-lab' },
+})
+
+new aws.iam.RolePolicy('forms-lab-bedrock', {
+  role: role.id,
+  policy: JSON.stringify({
+    Version: '2012-10-17',
+    Statement: [
+      {
+        Effect: 'Allow',
+        Action: ['bedrock:InvokeModel', 'bedrock:InvokeModelWithResponseStream'],
+        Resource: 'arn:aws:bedrock:us-east-1::foundation-model/*',
+      },
+    ],
+  }),
+})
+
+const instanceProfile = new aws.iam.InstanceProfile('forms-lab-profile', {
+  role: role.name,
+})
+
 // EC2 instance
 const instance = new aws.ec2.Instance('forms-lab', {
   ami: nixosAmi.then((ami) => ami.id),
   instanceType: 't3.small',
   keyName: keyPair.keyName,
   vpcSecurityGroupIds: [sg.id],
+  iamInstanceProfile: instanceProfile.name,
   rootBlockDevice: {
     volumeSize: 30,
     volumeType: 'gp3',


### PR DESCRIPTION
## Context

Story 3 (PDF upload + extraction) uses the Bedrock SDK to call Claude for PDF extraction. When deployed to EC2, the branch app fails with:

> AWS region setting is missing. Pass it using the 'region' parameter or the AWS_REGION environment variable.

Additionally, the EC2 instance has no AWS credentials for Bedrock API calls — it needs an IAM instance profile.

## Changes

- **IAM role + instance profile** (`infrastructure/pulumi/index.ts`): Creates a role with `bedrock:InvokeModel` and `bedrock:InvokeModelWithResponseStream` permissions scoped to `arn:aws:bedrock:us-east-1::foundation-model/*`. Attaches it to the EC2 instance via an instance profile.
- **Deploy script** (`infrastructure/nixos/modules/deploy.nix`): Adds `AWS_REGION=us-east-1` to the per-branch `.env` file written during deployment.

## Testing

- [ ] `pulumi up` provisions the IAM role and attaches the instance profile
- [ ] `nixos apply` updates the deploy script on the server
- [ ] Story-3 branch redeploys and Bedrock extraction succeeds

## Notes

- The instance profile provides credentials via the EC2 metadata service — no static access keys needed
- Permissions are scoped to foundation models only (no model customization or training access)
- `AWS_REGION` is required by the `@ai-sdk/amazon-bedrock` provider at runtime