### PR TITLE
infra(bedrock): add cross-region inference profile to IAM policy

### DIFF
--- a/infrastructure/pulumi/index.ts
+++ b/infrastructure/pulumi/index.ts
@@ -80,8 +80,16 @@ new aws.iam.RolePolicy('forms-lab-bedrock', {
     Statement: [
       {
         Effect: 'Allow',
-        Action: ['bedrock:InvokeModel', 'bedrock:InvokeModelWithResponseStream'],
-        Resource: 'arn:aws:bedrock:us-east-1::foundation-model/*',
+        Action: [
+          'bedrock:InvokeModel',
+          'bedrock:InvokeModelWithResponseStream',
+        ],
+        Resource: [
+          // Direct model invocation
+          'arn:aws:bedrock:us-east-1::foundation-model/*',
+          // Cross-region inference profiles (us.anthropic.* model IDs)
+          'arn:aws:bedrock:us-east-1:*:inference-profile/*',
+        ],
       },
     ],
   }),


### PR DESCRIPTION
## Context

Bedrock InvokeModel returns Forbidden when using cross-region inference model IDs (e.g., `us.anthropic.claude-sonnet-4-20250514-v1:0`). The IAM policy from PR #27 only included `arn:aws:bedrock:us-east-1::foundation-model/*`, which doesn't cover the inference profile ARN pattern used by cross-region routing.

## Changes

- Add `arn:aws:bedrock:us-east-1:*:inference-profile/*` to the Bedrock IAM policy resource list

## Testing

- [ ] `pulumi up` updates the IAM policy
- [ ] Bedrock extraction succeeds on the server