### PR TITLE
infra(bedrock): allow all US regions in IAM policy

### DIFF
--- a/infrastructure/pulumi/index.ts
+++ b/infrastructure/pulumi/index.ts
@@ -85,10 +85,11 @@ new aws.iam.RolePolicy('forms-lab-bedrock', {
           'bedrock:InvokeModelWithResponseStream',
         ],
         Resource: [
-          // Direct model invocation
-          'arn:aws:bedrock:us-east-1::foundation-model/*',
+          // Direct model invocation (any US region — cross-region
+          // inference routes to the least-loaded region)
+          'arn:aws:bedrock:us-*::foundation-model/*',
           // Cross-region inference profiles (us.anthropic.* model IDs)
-          'arn:aws:bedrock:us-east-1:*:inference-profile/*',
+          'arn:aws:bedrock:us-*:*:inference-profile/*',
         ],
       },
     ],


### PR DESCRIPTION
## Context

Cross-region inference (`us.anthropic.*` model IDs) routes to the least-loaded US region. The previous IAM policy only allowed `us-east-1`, but requests were routing to `us-east-2` and getting Forbidden.

## Changes

- Widen IAM policy resource ARNs from `us-east-1` to `us-*` for both foundation-model and inference-profile patterns

## Testing

- [ ] `pulumi up` updates the IAM policy
- [ ] Bedrock InvokeModel succeeds regardless of which US region handles the request