### PR TITLE
infra(bedrock): add CLI for cross-account SSO credential management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,11 @@ bun run cli webhook setup       # GitHub webhook configuration guide
 
 # Manual deployment
 bun run cli deploy homepage     # Update homepage service (dashboard)
+
+# Bedrock credentials (cross-account SSO)
+bun run cli bedrock-credentials login   # Login to Flexion LLM AWS SSO
+bun run cli bedrock-credentials push    # Copy SSO token to EC2 server
+bun run cli bedrock-credentials status  # Check if credentials are valid
 ```
 
 ### Deployment Architecture

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,3 +1,4 @@
+import { bedrockCredentials } from './commands/bedrock-credentials'
 import { deploy } from './commands/deploy'
 import { infra } from './commands/infra'
 import { nixos } from './commands/nixos'
@@ -17,6 +18,11 @@ export interface Command {
 }
 
 const commands: Command[] = [
+  {
+    name: 'bedrock-credentials',
+    description: 'Manage cross-account Bedrock SSO credentials',
+    run: bedrockCredentials,
+  },
   {
     name: 'sync-stories',
     description: 'Sync user stories from GitHub Issues',

--- a/src/commands/bedrock-credentials.ts
+++ b/src/commands/bedrock-credentials.ts
@@ -1,0 +1,213 @@
+import { resolve } from 'node:path'
+
+const pulumiDir = resolve(import.meta.dir, '../../infrastructure/pulumi')
+
+const BEDROCK_PROFILE = 'ClaudeCodeAccess-FlexionLLM'
+const SSO_START_URL = 'https://d-9a6729e262.awsapps.com/start'
+const SSO_REGION = 'us-east-2'
+const SSO_ACCOUNT_ID = '529237317113'
+const SSO_ROLE_NAME = 'ClaudeCodeAccess'
+const BEDROCK_REGION = 'us-west-2'
+
+function printUsage(): void {
+  console.log('Usage: bun run cli bedrock-credentials <subcommand>\n')
+  console.log('Subcommands:')
+  console.log('  login        Login to AWS SSO for Bedrock access')
+  console.log('  push         Copy SSO credentials to EC2 server')
+  console.log('  status       Check if Bedrock credentials are valid on server')
+  console.log()
+  console.log('Background:')
+  console.log(
+    '  Forms Lab runs in AWS account 165286508758 (llm-class profile),',
+  )
+  console.log(
+    '  but Bedrock model access requires account 529237317113 (FlexionLLM).',
+  )
+  console.log(
+    '  This command manages SSO credentials for cross-account Bedrock access.',
+  )
+  console.log()
+  console.log('  SSO tokens expire after ~8 hours. Re-run `login` then `push`')
+  console.log('  to refresh.')
+}
+
+async function getHostname(): Promise<string | null> {
+  const proc = Bun.spawn(['pulumi', 'stack', 'output', 'hostname'], {
+    cwd: pulumiDir,
+    stdout: 'pipe',
+    env: { ...process.env, AWS_PROFILE: 'llm-class' },
+  })
+  const text = await new Response(proc.stdout).text()
+  const code = await proc.exited
+  return code === 0 ? text.trim() : null
+}
+
+async function ensureAwsConfig(hostname: string): Promise<void> {
+  const configContent = `[profile ${BEDROCK_PROFILE}]
+sso_start_url = ${SSO_START_URL}
+sso_region = ${SSO_REGION}
+sso_account_id = ${SSO_ACCOUNT_ID}
+sso_role_name = ${SSO_ROLE_NAME}
+region = ${BEDROCK_REGION}
+
+[sso-session ${BEDROCK_PROFILE}]
+sso_start_url = ${SSO_START_URL}
+sso_region = ${SSO_REGION}
+sso_registration_scopes = sso:account:access
+`
+  const proc = Bun.spawn(
+    [
+      'ssh',
+      `root@${hostname}`,
+      `mkdir -p /root/.aws/sso/cache && cat > /root/.aws/config << 'AWSEOF'\n${configContent}AWSEOF`,
+    ],
+    { stdio: ['inherit', 'inherit', 'inherit'] },
+  )
+  await proc.exited
+}
+
+async function findSsoCacheFile(): Promise<string | null> {
+  const { readdirSync, readFileSync } = await import('node:fs')
+  const { join } = await import('node:path')
+  const home = process.env.HOME ?? ''
+  const cacheDir = join(home, '.aws', 'sso', 'cache')
+
+  try {
+    const files = readdirSync(cacheDir)
+    for (const file of files) {
+      if (!file.endsWith('.json')) continue
+      try {
+        const content = readFileSync(join(cacheDir, file), 'utf-8')
+        const data = JSON.parse(content)
+        if (
+          data.startUrl === SSO_START_URL &&
+          data.accessToken &&
+          data.expiresAt
+        ) {
+          const expires = new Date(data.expiresAt)
+          if (expires > new Date()) {
+            return join(cacheDir, file)
+          }
+          console.error(
+            `SSO token expired at ${data.expiresAt}. Run: bun run cli bedrock-credentials login`,
+          )
+          return null
+        }
+      } catch {}
+    }
+  } catch {
+    // cache dir doesn't exist
+  }
+
+  console.error(
+    `No valid SSO token found for ${SSO_START_URL}. Run: bun run cli bedrock-credentials login`,
+  )
+  return null
+}
+
+export async function bedrockCredentials(args: string[]): Promise<number> {
+  const subcommand = args[0]
+
+  switch (subcommand) {
+    case 'login': {
+      console.log(`Logging in to AWS SSO (${BEDROCK_PROFILE})...`)
+      console.log(
+        `Account: ${SSO_ACCOUNT_ID} | Role: ${SSO_ROLE_NAME} | Region: ${SSO_REGION}\n`,
+      )
+      const proc = Bun.spawn(
+        ['aws', 'sso', 'login', '--profile', BEDROCK_PROFILE],
+        { stdio: ['inherit', 'inherit', 'inherit'] },
+      )
+      const code = await proc.exited
+      if (code === 0) {
+        console.log(
+          '\nLogin successful. Now run: bun run cli bedrock-credentials push',
+        )
+      }
+      return code
+    }
+
+    case 'push': {
+      const hostname = await getHostname()
+      if (!hostname) {
+        console.error('Could not get hostname from Pulumi outputs')
+        return 1
+      }
+
+      const cacheFile = await findSsoCacheFile()
+      if (!cacheFile) return 1
+
+      console.log(`Pushing Bedrock credentials to ${hostname}...`)
+
+      // Ensure AWS config exists on server
+      await ensureAwsConfig(hostname)
+
+      // Copy SSO cache file
+      const scp = Bun.spawn(
+        ['scp', cacheFile, `root@${hostname}:/root/.aws/sso/cache/`],
+        { stdio: ['inherit', 'inherit', 'inherit'] },
+      )
+      const scpCode = await scp.exited
+      if (scpCode !== 0) {
+        console.error('Failed to copy SSO cache')
+        return 1
+      }
+
+      // Restart branch services so they pick up credentials
+      console.log('Restarting branch services...')
+      const restart = Bun.spawn(
+        [
+          'ssh',
+          `root@${hostname}`,
+          'systemctl restart "forms-lab-app@*.service" 2>/dev/null; echo "Services restarted"',
+        ],
+        { stdio: ['inherit', 'inherit', 'inherit'] },
+      )
+      await restart.exited
+
+      console.log('Done. Bedrock credentials pushed to server.')
+      return 0
+    }
+
+    case 'status': {
+      const hostname = await getHostname()
+      if (!hostname) {
+        console.error('Could not get hostname from Pulumi outputs')
+        return 1
+      }
+
+      console.log(`Checking Bedrock credentials on ${hostname}...\n`)
+      const proc = Bun.spawn(
+        [
+          'ssh',
+          `root@${hostname}`,
+          `cd /srv/forms-lab/main 2>/dev/null || cd /srv/forms-lab/story-3-pdf-upload && bun -e '
+async function check() {
+  const { fromIni } = await import("@aws-sdk/credential-providers");
+  try {
+    const creds = await fromIni({ profile: "${BEDROCK_PROFILE}" })();
+    const expires = creds.expiration ? creds.expiration.toISOString() : "unknown";
+    console.log("Status: Valid");
+    console.log("Account: ${SSO_ACCOUNT_ID}");
+    console.log("Profile: ${BEDROCK_PROFILE}");
+    console.log("Expires:", expires);
+  } catch(e) {
+    console.log("Status: INVALID");
+    console.log("Error:", e.message);
+    console.log("\\nRun: bun run cli bedrock-credentials login && bun run cli bedrock-credentials push");
+    process.exit(1);
+  }
+}
+check();
+'`,
+        ],
+        { stdio: ['inherit', 'inherit', 'inherit'] },
+      )
+      return await proc.exited
+    }
+
+    default:
+      printUsage()
+      return subcommand ? 1 : 0
+  }
+}


### PR DESCRIPTION
## Context

Forms Lab EC2 runs in AWS account `165286508758` (llm-class), but Bedrock model access requires account `529237317113` (FlexionLLM). A Marketplace SCP in the llm-class account prevents first-invocation model activation, making Bedrock unusable from the instance profile.

## Changes

- Add `bun run cli bedrock-credentials` command with `login`, `push`, and `status` subcommands
- `login`: Opens browser-based AWS SSO authentication for the FlexionLLM profile
- `push`: Copies the local SSO token cache to the EC2 server and restarts branch services
- `status`: Verifies credentials are valid on the server
- Update CLAUDE.md with the new commands

## Usage

```bash
bun run cli bedrock-credentials login   # Authenticate (opens browser)
bun run cli bedrock-credentials push    # Copy token to server
bun run cli bedrock-credentials status  # Verify
```

SSO tokens expire after ~8 hours. This is a workaround until cross-account role assumption or SCP changes can be arranged.

## Testing

- [x] Lint passes
- [x] Type check passes
- [x] Tests pass (124/124)