### PR TITLE
feat(notify): add notification service for operational alerts

### DIFF
--- a/infrastructure/nixos/configuration.nix
+++ b/infrastructure/nixos/configuration.nix
@@ -67,6 +67,9 @@
     secrets.session-secret = {
       owner = "forms-lab";
     };
+    secrets.slack-webhook-url = {
+      owner = "forms-lab";
+    };
   };
 
   # Allow forms-lab user to manage its own services and reload Caddy

--- a/infrastructure/nixos/flake.nix
+++ b/infrastructure/nixos/flake.nix
@@ -26,6 +26,8 @@
         ./modules/app.nix
         ./modules/deploy.nix
         ./modules/homepage.nix
+        ./modules/notify.nix
+        ./modules/notify-failure.nix
       ];
     };
 

--- a/infrastructure/nixos/modules/app.nix
+++ b/infrastructure/nixos/modules/app.nix
@@ -16,6 +16,7 @@
       ExecStart = "${pkgs.bun}/bin/bun run src/app/main.ts";
       Restart = "on-failure";
       RestartSec = 5;
+      OnFailure = "forms-lab-notify-failure@%n.service";
 
       # Environment loaded from a per-branch env file written by deploy script
       EnvironmentFile = "/srv/forms-lab/%i/.env";

--- a/infrastructure/nixos/modules/homepage.nix
+++ b/infrastructure/nixos/modules/homepage.nix
@@ -20,6 +20,7 @@
         "PORT=3000"
       ];
       ExecStart = "${pkgs.bun}/bin/bun run src/homepage/main.ts";
+      OnFailure = "forms-lab-notify-failure@%n.service";
     };
   };
 }

--- a/infrastructure/nixos/modules/notify-failure.nix
+++ b/infrastructure/nixos/modules/notify-failure.nix
@@ -1,0 +1,25 @@
+{ config, pkgs, ... }:
+
+let
+  notifyFailureScript = pkgs.writeShellScriptBin "forms-lab-notify-failure" ''
+    UNIT="$1"
+    ${pkgs.curl}/bin/curl -s -X POST http://localhost:9001/event \
+      -H "Content-Type: application/json" \
+      -d "{\"type\":\"service.crashed\",\"title\":\"Service $UNIT crashed\",\"status\":\"failure\",\"details\":\"Systemd unit $UNIT entered failed state\"}" \
+      || true
+  '';
+in
+{
+  environment.systemPackages = [ notifyFailureScript ];
+
+  # Template unit triggered by OnFailure= in other services
+  systemd.services."forms-lab-notify-failure@" = {
+    description = "Notify on failure of %i";
+    serviceConfig = {
+      Type = "oneshot";
+      User = "forms-lab";
+      Group = "forms-lab";
+      ExecStart = "${notifyFailureScript}/bin/forms-lab-notify-failure %i";
+    };
+  };
+}

--- a/infrastructure/nixos/modules/notify.nix
+++ b/infrastructure/nixos/modules/notify.nix
@@ -1,0 +1,26 @@
+{ config, pkgs, lib, ... }:
+
+{
+  systemd.services.forms-lab-notify = {
+    description = "Forms Lab Notification Service";
+    wantedBy = [ "multi-user.target" ];
+    after = [ "network.target" ];
+
+    path = with pkgs; [ bun ];
+
+    serviceConfig = {
+      Type = "simple";
+      User = "forms-lab";
+      Group = "forms-lab";
+      WorkingDirectory = "/srv/forms-lab";
+      Restart = "on-failure";
+      RestartSec = 5;
+    };
+
+    script = ''
+      export SLACK_WEBHOOK_URL=$(cat ${config.sops.secrets.slack-webhook-url.path})
+      export PORT=9001
+      exec ${pkgs.bun}/bin/bun run /srv/forms-lab/main/src/notify/main.ts
+    '';
+  };
+}

--- a/infrastructure/nixos/modules/webhook.nix
+++ b/infrastructure/nixos/modules/webhook.nix
@@ -15,6 +15,7 @@
       WorkingDirectory = "/srv/forms-lab";
       Restart = "on-failure";
       RestartSec = 5;
+      OnFailure = "forms-lab-notify-failure@%n.service";
     };
 
     # sops-nix decrypts the secret to a file containing the raw value.

--- a/infrastructure/nixos/secrets.yaml
+++ b/infrastructure/nixos/secrets.yaml
@@ -1,20 +1,21 @@
-github-webhook-secret: ENC[AES256_GCM,data:XGrQMWleGy5YlOP2a4pQWdu4g+swDtHq+GG4/s1eovbUigorp49hp34ysP7l5zEnvuLBz9vwUvxMjVRuJhW6jg==,iv:QJxWZ6KWOGAO684/gUKHi+LxPd1M2WoqtsdNs8/Kfuk=,tag:znpUJdnJOLaQU2CDA9T/Zw==,type:str]
-github-token: ENC[AES256_GCM,data:xmJDFNq0MKzUmThDbf4bgrxgpbuHAV9H/jO2/DUPpFmAu0uxBsKI73ku6pFeVApYZ2CRETipT1M1YNGqeUbilrnKmn8lUURYWAkagmjBrm2t36uj1oeTWm2plL9I,iv:TRy48MyO6Ey7uYsYcHdgDYn1ieYkdXgYa26sw7bK4us=,tag:jKU5K+5xUiytVnQE+x+tzA==,type:str]
-github-client-id: ENC[AES256_GCM,data:h6ikeiasUbzY1ECY+3KUovz8z5Q=,iv:7gQ3OsbX8t6lb4Rr8OTfeg6CSmKRLilF0EOHaH+oD/g=,tag:1pqKXM9neQKXPvmTHQ1S4g==,type:str]
-github-client-secret: ENC[AES256_GCM,data:MUFWmn1XVGR/yHdhLyjtVwop9KoXcjkRHVza7uUfE8WuB5knZdirLQ==,iv:1nUTXPTyguKvMx7QNJovsixQTTs7lCwdI+RPL432N90=,tag:byojEnpGNAMZ7duYuRLffQ==,type:str]
-session-secret: ENC[AES256_GCM,data:4wSwuUM2fY+mrnSMbdGRVyoJfO04BwgDqEYT1zFQdjV1SYha1JWBn8KFbk4=,iv:nJiku31CJfkncf4UrMZUNN6JiJOaxQ3IsFJtfnOrtTU=,tag:5+er1u0/W1Wg7rVH0TSMbw==,type:str]
+github-webhook-secret: ENC[AES256_GCM,data:dQjHPR/HftiQYPikihjaTgsBCoWyu4CNjvGaPhB9wDza1YmBtOh5EKu//ezvBqFtvMoaVgZaDeaFGeDtyZ5VoQ==,iv:9QNDVlPg89c2PNbeTxAA8SaicMSMErUBW9YdIeSCxDY=,tag:pyOul+rFEB+nT4e7H0crTQ==,type:str]
+github-token: ENC[AES256_GCM,data:v73DG8qBQL1xYq4JTLu+eABLpWf+NyU1y9WK5rhjOsgX7REhBcAhQw5f55Eq61s4B1mAiKwEv/+cGJE8L/JGkhzVUYLyKMALG9S4IKkkYBDta9jSVkDi4w5A5tlH,iv:D3gfsgjYcrzjrTtPX+HCtaRVFfAk5O9SKV1Z1GO0wEk=,tag:9tNQ3UmA10vLfoVgeFrgvw==,type:str]
+github-client-id: ENC[AES256_GCM,data:2IkX2ABHwFfdBoMgdqCknEMZrhw=,iv:AH0O93Jgi9Ir9EQjpnpKJmVO9HKVMb3tR5T95LLDh/E=,tag:dQalbQw2S1VcKG9wj/fXDw==,type:str]
+github-client-secret: ENC[AES256_GCM,data:j/D9CH0/pzwaZXbNTbwO8AyXJCKrPXUvOf+KtbDWKb/PM0ORhKmAaA==,iv:w66U3mwYvRqYGK2avJMZ33x4MtlAGziu1OttQSwsr48=,tag:XSRuOgn5u4PfUEHvLsyGkg==,type:str]
+session-secret: ENC[AES256_GCM,data:fJ4AFqMpYK7CgdsOHsZVZRZcyIq1u/hyJB6RGLoxVhQw37VF7Hq5cYOJRL0=,iv:Rj4ToqRZJlL4j00jepcKn5VkyOnyGgKorVSFb6ZpUV4=,tag:gf+vg3VryYGFrwB/CEG7Mg==,type:str]
+slack-webhook-url: ENC[AES256_GCM,data:YYQD9XMDqmgR0uUjesi/SM5lnTCC3mx75UyLbZAmttCxAIyD/jLIu4XlLz89A86Iib18hB/XJBvf8O8zgRH2qd9x1nsDm65p6zAHzcQrFQw3,iv:sOHL1+u3KIGCsGeX8qAagJWjf5FioXu1U2N1tm+Itdc=,tag:JQRCT8xMZkdEa/YofvcrCA==,type:str]
 sops:
     age:
         - recipient: age1u7jjhjuhj9nuzdxygdjrv80z6xvea7pq73jezpqm2xl4s6ty2ajstyyfth
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA5WjMxNDhQaUFTR2p3MmZ0
-            aGcrK3VtL3pOR29zZU84U2VlaVFGWUFPOHd3CjRyUUM1MnlaczMyR1FkaUtIWDN6
-            UzA2ZnJwUnFXK0VnV1pKRGJEUlR4V00KLS0tIDRmYXZPWWQ3dG5ac1V5UTNKTnN3
-            OTZEZVYvSElrbS9JTEhJam8rUi9sbXMKRtpBQvLDRXgiwQwjQj4SQZLlh6/cikIe
-            tJylsePrwgBP3eVMTvhnVhGnmiOjI5HRgDHTfyQ7v2moNFty/4/ZAA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBoL0lTY1paSm4xT3k0OW4r
+            TW9oTENWU2Vsc3pjY2V6TEdsSFdpWkZZcHlVCk5zNm1EWFpwTDZrYzV3OG8rWHJ1
+            c2N2VWNpa3RPRUxTQ05rQ0VlZ25tSmMKLS0tIGJxVEMvbjVLUENQTG9yQytDU1dR
+            cVN6NzhIOGlJSmFiY0FqYkMxQkkxY3MK8xZqmh1DbJKiFraaW6kFF5jmYCsYNDNK
+            JuuZ3TTqMpd/RjHMm+HlWsZtJEHu73BqYvC6jsudgrNjVn7QvBA7xw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-10T15:50:55Z"
-    mac: ENC[AES256_GCM,data:jwqa9aAYkqspbkqk6vy90LLSq5qni1fXKyA/1DSyYNchT0Pfik7987GO/k0ZZFrEnw3897Vp/zX32fNTuGGnWaKO1WMmiFryi50YXpqvz8pN5hW+ZmcBsYetJc3F7t7mqpNFPcgWlgtcf9ztTv6bzHUtoMIfFv4RknGYOBFRccM=,iv:CdG6T/ifl8K2I3C3/meMKK/bpnhf/FRb9//2xE2htBU=,tag:7pu5yraQMq/JvyZA1Jnnrw==,type:str]
+    lastmodified: "2026-04-11T19:45:01Z"
+    mac: ENC[AES256_GCM,data:fArDqR+6nDhxckOtTxFx0XF4wBq03xF+VR3lvzA1AUk/CfNLKEU7ThJ0ST7TknfBNTR1EsH+PrFkwzLINvbluCr8enq1BWjdlU5o1cns3Bbfu3VHIzAH38AuDExnoUDLwwfD/biIhGsx+a4uj0pahLkpsPmECYAtx8O1542v+K8=,iv:MEcs1yjw4KlkvDTKNLLXOu6xU1SobagD+KEULQpG59w=,tag:NgAXDXQYlBUQRnbRV9LrwA==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2

--- a/notes/2026-04-11-notify-service/design.md
+++ b/notes/2026-04-11-notify-service/design.md
@@ -1,0 +1,142 @@
+# Notify Service Design
+
+**Date:** 2026-04-11
+**Status:** draft
+
+## Problem
+
+The forms-lab deployment infrastructure has no operational alerting. Deploy failures, service crashes, health check failures, and NixOS rebuild errors are only visible in journald logs or GitHub deployment statuses. Nobody gets proactively notified.
+
+## Goals
+
+- Real-time Slack notifications for operational events (deploy success/failure, service crashes, health check failures, NixOS rebuild failures)
+- Extensible to application-level events later (logins, user activity)
+- Single notification service as the event sink, avoiding scattered Slack calls across the codebase
+
+## Non-Goals
+
+- Persistent event storage or audit log
+- Retry/queue semantics (fire-and-forget is acceptable at this scale)
+- External monitoring agents or third-party services beyond Slack
+
+## Architecture
+
+A new Hono HTTP service (`forms-lab-notify`) running on port 9001, internal-only (not exposed through Caddy). Components POST JSON events to it; it formats and forwards to Slack via incoming webhook.
+
+```
+Deploy script (deploy.sh) ──POST──┐
+Systemd OnFailure units ──────────┤
+Webhook handler (deploy.ts) ──────┼──> notify service (:9001) ──> Slack webhook
+App routes (future) ──────────────┘
+```
+
+### Event Payload
+
+```typescript
+interface NotifyEvent {
+  type: string;       // dot-namespaced: "deploy.success", "service.crashed"
+  title: string;      // human-readable summary
+  status: "success" | "failure" | "info";
+  details?: string;   // optional extra context
+  timestamp?: string; // ISO 8601, defaults to server time
+}
+```
+
+### Initial Event Types
+
+| Type | Source | Status | Example title |
+|------|--------|--------|---------------|
+| `deploy.success` | webhook deploy.ts | success | "Deployed `main` at abc1234" |
+| `deploy.failure` | webhook deploy.ts | failure | "Deploy failed for `main`: build error" |
+| `service.crashed` | systemd OnFailure | failure | "Service `forms-lab-app@main` crashed" |
+| `health.failure` | webhook deploy.ts | failure | "Health check failed for main after deploy" |
+| `nixos.rebuild.failure` | webhook deploy.ts | failure | "NixOS rebuild failed during main deploy" |
+
+### Future Event Types (not built now)
+
+| Type | Source | Status |
+|------|--------|--------|
+| `app.login` | app auth route | info |
+| `app.submission` | app form route | info |
+
+## Service Implementation
+
+**Location:** `src/notify/`
+
+**Files:**
+- `main.ts` -- Hono server, `POST /event` and `GET /health` routes
+- `slack.ts` -- Formats `NotifyEvent` into Slack attachment, posts via webhook URL
+- `types.ts` -- `NotifyEvent` interface and validation
+
+### Routes
+
+- `POST /event` -- Validates payload, formats Slack message, posts to Slack. Returns 200 on success, 400 for bad payload, 502 if Slack rejects.
+- `GET /health` -- Returns 200 with `{ status: "ok", service: "notify" }`.
+
+### Slack Message Format
+
+Uses the Slack attachments API with color-coded sidebar:
+- `success` = `#2eb886` (green)
+- `failure` = `#dc3545` (red)
+- `info` = `#6c757d` (gray)
+
+Example message:
+```
+[deploy.success] Deployed `main` at abc1234
+Build completed in 42s
+2026-04-11T15:45:00Z
+```
+
+### Environment
+
+- `SLACK_WEBHOOK_URL` -- Slack incoming webhook URL (via sops-nix)
+- `PORT` -- defaults to 9001
+
+### Error Handling
+
+- Invalid JSON or missing required fields returns 400
+- Slack API failure returns 502, logs to stderr (journald)
+- No retries -- callers are fire-and-forget
+
+## Integration Points
+
+### 1. Webhook Handler (deploy.ts)
+
+Modify `triggerDeployWithStatus` and `deployMainBranch` to POST events to the notify service after deploy completes:
+
+- On deploy success: POST `deploy.success`
+- On deploy failure: POST `deploy.failure`
+- On health check failure: POST `health.failure`
+- On NixOS rebuild failure: POST `nixos.rebuild.failure`
+
+This is a `fetch("http://localhost:9001/event", ...)` call. If the notify service is down, the fetch fails silently and deployment continues unaffected.
+
+A small helper function `notifyEvent(event: NotifyEvent)` in `src/notify/client.ts` wraps the fetch for reuse across webhook handler and future app routes.
+
+### 2. Systemd OnFailure Units
+
+A template unit `forms-lab-notify-failure@.service` runs when any forms-lab service fails:
+
+```ini
+[Service]
+Type=oneshot
+ExecStart=<notify-failure-script> %i
+```
+
+The script curls `http://localhost:9001/event` with a `service.crashed` event containing the failed unit name.
+
+Existing service modules (`webhook.nix`, `app.nix`, `homepage.nix`) get `OnFailure=forms-lab-notify-failure@%n.service` added.
+
+### 3. NixOS Configuration
+
+- New `notify.nix` module for the `forms-lab-notify` systemd service
+- New `notify-failure.nix` module for the OnFailure template unit and script
+- Add `slack-webhook-url` to sops secrets in `configuration.nix`
+- Add both modules to `flake.nix`
+- Add `OnFailure=` to existing service modules
+
+## Testing
+
+- Unit tests for event validation and Slack message formatting (`test/notify-*.test.ts`)
+- Unit tests for the notify client helper
+- Integration of notify calls into existing webhook deploy tests (mock the fetch to localhost:9001)

--- a/notes/2026-04-11-notify-service/plan.md
+++ b/notes/2026-04-11-notify-service/plan.md
@@ -1,0 +1,78 @@
+# Notify Service Implementation Plan
+
+**Date:** 2026-04-11
+**Design:** [design.md](design.md)
+
+## Steps
+
+### Step 1: Types and Slack Formatter (independent)
+
+Create the core types and Slack formatting logic.
+
+**Files to create:**
+- `src/notify/types.ts` -- `NotifyEvent` interface, `NotifyStatus` type, `validateEvent()` function
+- `src/notify/slack.ts` -- `formatSlackMessage(event: NotifyEvent)` returns Slack attachment payload, `postToSlack(webhookUrl: string, event: NotifyEvent)` posts it
+
+**Tests to create:**
+- `test/notify-slack.test.ts` -- Tests for `formatSlackMessage` (correct colors per status, all fields present, missing optional fields handled) and `postToSlack` (mocks fetch, verifies payload shape, handles Slack errors)
+
+**TDD approach:** Write test for `validateEvent` first, then implement. Write test for `formatSlackMessage`, then implement. Write test for `postToSlack`, then implement.
+
+### Step 2: Notify Client Helper (independent)
+
+Create the client helper that other components use to fire events.
+
+**Files to create:**
+- `src/notify/client.ts` -- `notifyEvent(event: NotifyEvent): Promise<void>` that POSTs to `http://localhost:${NOTIFY_PORT}/event`, catches and logs errors silently
+
+**Tests to create:**
+- `test/notify-client.test.ts` -- Tests that it POSTs correct payload, handles connection refused gracefully, handles non-200 responses gracefully
+
+### Step 3: Hono Service (depends on Step 1)
+
+Create the HTTP server.
+
+**Files to create:**
+- `src/notify/main.ts` -- Hono app with `POST /event` and `GET /health`, reads `SLACK_WEBHOOK_URL` and `PORT` from env
+
+**Tests to create:**
+- `test/notify-service.test.ts` -- Tests for POST /event (valid payload returns 200, missing fields returns 400, bad JSON returns 400), GET /health returns 200
+
+### Step 4: Webhook Handler Integration (depends on Step 2)
+
+Modify deploy.ts to send notifications after deploys.
+
+**Files to modify:**
+- `src/webhook/deploy.ts` -- Import `notifyEvent` from client, call after deploy success/failure in `triggerDeployWithStatus` and `deployMainBranch`
+
+**Tests to modify:**
+- `test/webhook-deploy.test.ts` -- Verify notify events are sent on success and failure (mock the fetch)
+
+### Step 5: NixOS Modules (independent)
+
+Create the NixOS service configuration and OnFailure integration.
+
+**Files to create:**
+- `infrastructure/nixos/modules/notify.nix` -- systemd service for forms-lab-notify (mirrors webhook.nix pattern)
+- `infrastructure/nixos/modules/notify-failure.nix` -- OnFailure template unit and shell script
+
+**Files to modify:**
+- `infrastructure/nixos/flake.nix` -- Add `./modules/notify.nix` and `./modules/notify-failure.nix` to modules list
+- `infrastructure/nixos/configuration.nix` -- Add `slack-webhook-url` to sops secrets
+- `infrastructure/nixos/modules/webhook.nix` -- Add `OnFailure=forms-lab-notify-failure@%n.service`
+- `infrastructure/nixos/modules/app.nix` -- Add `OnFailure=forms-lab-notify-failure@%n.service`
+- `infrastructure/nixos/modules/homepage.nix` -- Add `OnFailure=forms-lab-notify-failure@%n.service`
+
+No automated tests for NixOS modules (they require nixos-rebuild to validate).
+
+## Parallelism
+
+Steps 1, 2, and 5 are independent and can run in parallel.
+Step 3 depends on Step 1.
+Step 4 depends on Step 2.
+
+```
+Step 1 (types + slack) ──> Step 3 (hono service)
+Step 2 (client helper) ──> Step 4 (webhook integration)
+Step 5 (nixos modules)
+```

--- a/src/notify/client.ts
+++ b/src/notify/client.ts
@@ -1,0 +1,17 @@
+import type { NotifyEvent } from './types'
+
+const NOTIFY_PORT = process.env.NOTIFY_PORT || '9001'
+const NOTIFY_URL = `http://localhost:${NOTIFY_PORT}/event`
+
+export async function notifyEvent(event: NotifyEvent): Promise<void> {
+  try {
+    await fetch(NOTIFY_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(event),
+    })
+  } catch {
+    // Fire-and-forget: log but don't throw
+    console.error(`Failed to send notification: ${event.type}`)
+  }
+}

--- a/src/notify/main.ts
+++ b/src/notify/main.ts
@@ -1,0 +1,45 @@
+import { Hono } from 'hono'
+import { postToSlack } from './slack'
+import { validateEvent } from './types'
+
+const app = new Hono()
+
+const slackWebhookUrl = process.env.SLACK_WEBHOOK_URL
+if (!slackWebhookUrl) {
+  console.error('SLACK_WEBHOOK_URL environment variable is required')
+  process.exit(1)
+}
+
+app.get('/health', (c) => {
+  return c.json({ status: 'ok', service: 'notify' })
+})
+
+app.post('/event', async (c) => {
+  let body: unknown
+  try {
+    body = await c.req.json()
+  } catch {
+    return c.json({ error: 'Invalid JSON' }, 400)
+  }
+
+  const result = validateEvent(body)
+  if (!result.valid) {
+    return c.json({ error: result.error }, 400)
+  }
+
+  const slackResult = await postToSlack(slackWebhookUrl, result.event)
+  if (!slackResult.ok) {
+    console.error('Slack post failed:', slackResult.error)
+    return c.json({ error: 'Failed to post to Slack' }, 502)
+  }
+
+  return c.json({ ok: true })
+})
+
+const port = process.env.PORT || 9001
+console.log(`Notify service running on port ${port}`)
+
+export default {
+  port: Number(port),
+  fetch: app.fetch,
+}

--- a/src/notify/slack.ts
+++ b/src/notify/slack.ts
@@ -1,0 +1,78 @@
+import type { NotifyEvent } from './types'
+
+const STATUS_COLORS: Record<string, string> = {
+  success: '#2eb886',
+  failure: '#dc3545',
+  info: '#6c757d',
+}
+
+export function formatSlackMessage(event: NotifyEvent): object {
+  const blocks: object[] = [
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `*[${event.type}]* ${event.title}`,
+      },
+    },
+  ]
+
+  if (event.details) {
+    blocks.push({
+      type: 'context',
+      elements: [
+        {
+          type: 'mrkdwn',
+          text: event.details,
+        },
+      ],
+    })
+  }
+
+  blocks.push({
+    type: 'context',
+    elements: [
+      {
+        type: 'mrkdwn',
+        text: event.timestamp ?? new Date().toISOString(),
+      },
+    ],
+  })
+
+  return {
+    attachments: [
+      {
+        color: STATUS_COLORS[event.status] ?? STATUS_COLORS.info,
+        fallback: event.title,
+        blocks,
+      },
+    ],
+  }
+}
+
+export async function postToSlack(
+  webhookUrl: string,
+  event: NotifyEvent,
+): Promise<{ ok: boolean; error?: string }> {
+  const payload = formatSlackMessage(event)
+
+  try {
+    const response = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
+
+    if (!response.ok) {
+      return {
+        ok: false,
+        error: `Slack responded with ${response.status}: ${await response.text()}`,
+      }
+    }
+
+    return { ok: true }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return { ok: false, error: message }
+  }
+}

--- a/src/notify/types.ts
+++ b/src/notify/types.ts
@@ -1,0 +1,52 @@
+export type NotifyStatus = 'success' | 'failure' | 'info'
+
+export interface NotifyEvent {
+  type: string
+  title: string
+  status: NotifyStatus
+  details?: string
+  timestamp?: string
+}
+
+const VALID_STATUSES: Set<string> = new Set(['success', 'failure', 'info'])
+
+export function validateEvent(
+  body: unknown,
+): { valid: true; event: NotifyEvent } | { valid: false; error: string } {
+  if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+    return { valid: false, error: 'body must be a non-null object' }
+  }
+
+  const obj = body as Record<string, unknown>
+
+  if (typeof obj.type !== 'string' || obj.type.length === 0) {
+    return { valid: false, error: 'type must be a non-empty string' }
+  }
+
+  if (typeof obj.title !== 'string' || obj.title.length === 0) {
+    return { valid: false, error: 'title must be a non-empty string' }
+  }
+
+  if (typeof obj.status !== 'string' || !VALID_STATUSES.has(obj.status)) {
+    return {
+      valid: false,
+      error: 'status must be one of: success, failure, info',
+    }
+  }
+
+  const event: NotifyEvent = {
+    type: obj.type,
+    title: obj.title,
+    status: obj.status as NotifyStatus,
+    timestamp:
+      typeof obj.timestamp === 'string'
+        ? obj.timestamp
+        : new Date().toISOString(),
+  }
+
+  if (typeof obj.details === 'string') {
+    event.details = obj.details
+  }
+
+  return { valid: true, event }
+}

--- a/src/webhook/deploy.ts
+++ b/src/webhook/deploy.ts
@@ -1,3 +1,4 @@
+import { notifyEvent } from '../notify/client'
 import type { GitHubClient } from '../services/github'
 
 export interface DeployResult {
@@ -98,14 +99,31 @@ export async function deployMainBranch(sha: string): Promise<DeployResult> {
 
     if (exitCode !== 0) {
       console.error(`Main deployment failed:`, stderr)
+      notifyEvent({
+        type: 'deploy.failure',
+        title: `Main deployment failed at ${sha.slice(0, 7)}`,
+        status: 'failure',
+        details: stderr.slice(0, 500) || undefined,
+      })
       return { success: false, error: stderr, stdout, stderr }
     }
 
     console.log(`Main deployment succeeded:`, stdout)
+    notifyEvent({
+      type: 'deploy.success',
+      title: `Main deployment succeeded at ${sha.slice(0, 7)}`,
+      status: 'success',
+    })
     return { success: true, stdout, stderr }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
     console.error(`Main deployment error:`, message)
+    notifyEvent({
+      type: 'deploy.failure',
+      title: `Main deployment error at ${sha.slice(0, 7)}`,
+      status: 'failure',
+      details: message.slice(0, 500),
+    })
     return { success: false, error: message }
   }
 }
@@ -144,6 +162,22 @@ export async function triggerDeployWithStatus(
   }
 
   const result = await triggerDeploy(branch, sha)
+
+  if (result.success) {
+    notifyEvent({
+      type: 'deploy.success',
+      title: `Deployed \`${branch}\` at ${sha.slice(0, 7)}`,
+      status: 'success',
+      details: result.stdout?.split('\n').pop() || undefined,
+    })
+  } else {
+    notifyEvent({
+      type: 'deploy.failure',
+      title: `Deploy failed for \`${branch}\``,
+      status: 'failure',
+      details: result.error?.slice(0, 500) || undefined,
+    })
+  }
 
   if (deploymentId) {
     try {

--- a/test/notify-client.test.ts
+++ b/test/notify-client.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { notifyEvent } from '../src/notify/client'
+
+describe('notifyEvent', () => {
+  let originalFetch: typeof globalThis.fetch
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('POSTs event to localhost notify service', async () => {
+    let capturedUrl = ''
+    let capturedInit: RequestInit | undefined
+
+    const mockFetch = async (input: unknown, init?: RequestInit) => {
+      capturedUrl = input as string
+      capturedInit = init
+      return new Response('ok', { status: 200 })
+    }
+    mockFetch.preconnect = (_url: string) => {}
+    globalThis.fetch = mockFetch as typeof fetch
+
+    await notifyEvent({
+      type: 'deploy.success',
+      title: 'Deployed main',
+      status: 'success',
+    })
+
+    expect(capturedUrl).toBe('http://localhost:9001/event')
+    expect(capturedInit?.method).toBe('POST')
+    expect(capturedInit?.headers).toEqual({
+      'Content-Type': 'application/json',
+    })
+
+    const body = JSON.parse(capturedInit?.body as string)
+    expect(body.type).toBe('deploy.success')
+    expect(body.title).toBe('Deployed main')
+    expect(body.status).toBe('success')
+  })
+
+  it('does not throw on connection failure', async () => {
+    const mockFetch = async (): Promise<Response> => {
+      throw new Error('Connection refused')
+    }
+    mockFetch.preconnect = (_url: string) => {}
+    globalThis.fetch = mockFetch as typeof fetch
+
+    // Should not throw
+    await notifyEvent({
+      type: 'deploy.failure',
+      title: 'Deploy failed',
+      status: 'failure',
+    })
+  })
+
+  it('does not throw on non-200 response', async () => {
+    const mockFetch = async () => {
+      return new Response('error', { status: 500 })
+    }
+    mockFetch.preconnect = (_url: string) => {}
+    globalThis.fetch = mockFetch as typeof fetch
+
+    // Should not throw
+    await notifyEvent({
+      type: 'test',
+      title: 'Test',
+      status: 'info',
+    })
+  })
+})

--- a/test/notify-service.test.ts
+++ b/test/notify-service.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+
+// The service reads SLACK_WEBHOOK_URL at import time, so set it before importing
+process.env.SLACK_WEBHOOK_URL = 'https://hooks.slack.com/test'
+process.env.PORT = '0' // let OS pick a port
+
+describe('notify service', () => {
+  let originalFetch: typeof globalThis.fetch
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('GET /health returns ok', async () => {
+    const { default: app } = await import('../src/notify/main')
+    const res = await app.fetch(new Request('http://localhost/health'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.status).toBe('ok')
+    expect(body.service).toBe('notify')
+  })
+
+  it('POST /event with valid payload returns 200', async () => {
+    const mockFetch = async () => new Response('ok', { status: 200 })
+    mockFetch.preconnect = (_url: string) => {}
+    globalThis.fetch = mockFetch as typeof fetch
+
+    const { default: app } = await import('../src/notify/main')
+    const res = await app.fetch(
+      new Request('http://localhost/event', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          type: 'deploy.success',
+          title: 'Deployed main',
+          status: 'success',
+        }),
+      }),
+    )
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.ok).toBe(true)
+  })
+
+  it('POST /event with invalid JSON returns 400', async () => {
+    const { default: app } = await import('../src/notify/main')
+    const res = await app.fetch(
+      new Request('http://localhost/event', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: 'not json',
+      }),
+    )
+
+    expect(res.status).toBe(400)
+  })
+
+  it('POST /event with missing fields returns 400', async () => {
+    const { default: app } = await import('../src/notify/main')
+    const res = await app.fetch(
+      new Request('http://localhost/event', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type: 'test' }),
+      }),
+    )
+
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toBeDefined()
+  })
+
+  it('POST /event returns 502 when Slack fails', async () => {
+    const mockFetch = async () =>
+      new Response('internal error', { status: 500 })
+    mockFetch.preconnect = (_url: string) => {}
+    globalThis.fetch = mockFetch as typeof fetch
+
+    const { default: app } = await import('../src/notify/main')
+    const res = await app.fetch(
+      new Request('http://localhost/event', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          type: 'test',
+          title: 'Test',
+          status: 'info',
+        }),
+      }),
+    )
+
+    expect(res.status).toBe(502)
+  })
+})

--- a/test/notify-slack.test.ts
+++ b/test/notify-slack.test.ts
@@ -1,0 +1,252 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { formatSlackMessage, postToSlack } from '../src/notify/slack'
+import type { NotifyEvent } from '../src/notify/types'
+import { validateEvent } from '../src/notify/types'
+
+describe('validateEvent', () => {
+  it('accepts a valid event with all fields', () => {
+    const result = validateEvent({
+      type: 'deploy.success',
+      title: 'Deployed main',
+      status: 'success',
+      details: 'Branch deployed in 42s',
+      timestamp: '2026-04-11T12:00:00Z',
+    })
+
+    expect(result.valid).toBe(true)
+    if (result.valid) {
+      expect(result.event.type).toBe('deploy.success')
+      expect(result.event.title).toBe('Deployed main')
+      expect(result.event.status).toBe('success')
+      expect(result.event.details).toBe('Branch deployed in 42s')
+      expect(result.event.timestamp).toBe('2026-04-11T12:00:00Z')
+    }
+  })
+
+  it('accepts a valid event with only required fields and defaults timestamp', () => {
+    const before = new Date().toISOString()
+    const result = validateEvent({
+      type: 'service.crashed',
+      title: 'Webhook down',
+      status: 'failure',
+    })
+    const after = new Date().toISOString()
+
+    expect(result.valid).toBe(true)
+    if (result.valid) {
+      const ts = result.event.timestamp ?? ''
+      expect(ts).not.toBe('')
+      expect(ts >= before).toBe(true)
+      expect(ts <= after).toBe(true)
+      expect(result.event.details).toBeUndefined()
+    }
+  })
+
+  it('rejects non-object input', () => {
+    const result = validateEvent('not an object')
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.error).toContain('object')
+    }
+  })
+
+  it('rejects null input', () => {
+    const result = validateEvent(null)
+    expect(result.valid).toBe(false)
+  })
+
+  it('rejects missing type', () => {
+    const result = validateEvent({ title: 'x', status: 'info' })
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.error).toContain('type')
+    }
+  })
+
+  it('rejects missing title', () => {
+    const result = validateEvent({ type: 'x', status: 'info' })
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.error).toContain('title')
+    }
+  })
+
+  it('rejects missing status', () => {
+    const result = validateEvent({ type: 'x', title: 'y' })
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.error).toContain('status')
+    }
+  })
+
+  it('rejects invalid status value', () => {
+    const result = validateEvent({
+      type: 'x',
+      title: 'y',
+      status: 'warning',
+    })
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.error).toContain('status')
+    }
+  })
+})
+
+describe('formatSlackMessage', () => {
+  const baseEvent: NotifyEvent = {
+    type: 'deploy.success',
+    title: 'Deployed main',
+    status: 'success',
+    timestamp: '2026-04-11T12:00:00Z',
+  }
+
+  it('uses correct color for success', () => {
+    const msg = formatSlackMessage(baseEvent) as {
+      attachments: Array<{ color: string }>
+    }
+    expect(msg.attachments[0].color).toBe('#2eb886')
+  })
+
+  it('uses correct color for failure', () => {
+    const msg = formatSlackMessage({ ...baseEvent, status: 'failure' }) as {
+      attachments: Array<{ color: string }>
+    }
+    expect(msg.attachments[0].color).toBe('#dc3545')
+  })
+
+  it('uses correct color for info', () => {
+    const msg = formatSlackMessage({ ...baseEvent, status: 'info' }) as {
+      attachments: Array<{ color: string }>
+    }
+    expect(msg.attachments[0].color).toBe('#6c757d')
+  })
+
+  it('includes title in output', () => {
+    const msg = formatSlackMessage(baseEvent)
+    const text = JSON.stringify(msg)
+    expect(text).toContain('Deployed main')
+  })
+
+  it('includes type in output', () => {
+    const msg = formatSlackMessage(baseEvent)
+    const text = JSON.stringify(msg)
+    expect(text).toContain('deploy.success')
+  })
+
+  it('includes details when present', () => {
+    const msg = formatSlackMessage({
+      ...baseEvent,
+      details: 'Took 42 seconds',
+    })
+    const text = JSON.stringify(msg)
+    expect(text).toContain('Took 42 seconds')
+  })
+
+  it('omits details block when details absent', () => {
+    const msg = formatSlackMessage(baseEvent) as {
+      attachments: Array<{ blocks: Array<{ type: string }> }>
+    }
+    // Should have section + timestamp context only (2 blocks), no details context
+    const contextBlocks = msg.attachments[0].blocks.filter(
+      (b) => b.type === 'context',
+    )
+    expect(contextBlocks).toHaveLength(1) // only timestamp
+  })
+
+  it('includes details block when details present', () => {
+    const msg = formatSlackMessage({
+      ...baseEvent,
+      details: 'Extra info',
+    }) as {
+      attachments: Array<{ blocks: Array<{ type: string }> }>
+    }
+    const contextBlocks = msg.attachments[0].blocks.filter(
+      (b) => b.type === 'context',
+    )
+    expect(contextBlocks).toHaveLength(2) // details + timestamp
+  })
+})
+
+describe('postToSlack', () => {
+  let originalFetch: typeof globalThis.fetch
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('sends POST with correct payload on success', async () => {
+    let capturedUrl = ''
+    let capturedInit: RequestInit | undefined
+
+    const mockFetch = async (input: unknown, init?: RequestInit) => {
+      capturedUrl = input as string
+      capturedInit = init
+      return new Response('ok', { status: 200 })
+    }
+    mockFetch.preconnect = (_url: string) => {}
+    globalThis.fetch = mockFetch as typeof fetch
+
+    const event: NotifyEvent = {
+      type: 'deploy.success',
+      title: 'Deployed',
+      status: 'success',
+      timestamp: '2026-04-11T12:00:00Z',
+    }
+
+    const result = await postToSlack('https://hooks.slack.com/test', event)
+
+    expect(result.ok).toBe(true)
+    expect(capturedUrl).toBe('https://hooks.slack.com/test')
+    expect(capturedInit?.method).toBe('POST')
+    expect(capturedInit?.headers).toEqual({
+      'Content-Type': 'application/json',
+    })
+
+    const body = JSON.parse(capturedInit?.body as string)
+    expect(body.attachments).toBeDefined()
+  })
+
+  it('returns error on non-200 response', async () => {
+    const mockFetch = async () => {
+      return new Response('bad request', { status: 400 })
+    }
+    mockFetch.preconnect = (_url: string) => {}
+    globalThis.fetch = mockFetch as typeof fetch
+
+    const event: NotifyEvent = {
+      type: 'test',
+      title: 'Test',
+      status: 'info',
+      timestamp: '2026-04-11T12:00:00Z',
+    }
+
+    const result = await postToSlack('https://hooks.slack.com/test', event)
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toBeDefined()
+  })
+
+  it('returns error on fetch exception', async () => {
+    const mockFetch = async (): Promise<Response> => {
+      throw new Error('Network error')
+    }
+    mockFetch.preconnect = (_url: string) => {}
+    globalThis.fetch = mockFetch as typeof fetch
+
+    const event: NotifyEvent = {
+      type: 'test',
+      title: 'Test',
+      status: 'info',
+      timestamp: '2026-04-11T12:00:00Z',
+    }
+
+    const result = await postToSlack('https://hooks.slack.com/test', event)
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain('Network error')
+  })
+})


### PR DESCRIPTION
## Summary

- Adds a lightweight Hono notification service (`forms-lab-notify`) on port 9001 that receives event POSTs and forwards to Slack via incoming webhook
- Integrates with the deploy pipeline — `deploy.ts` posts success/failure events after every deployment
- Adds systemd `OnFailure=` units to webhook, app, and homepage services for crash notifications
- NixOS modules for the notify service and failure notification template unit
- Slack webhook URL managed via sops-nix secrets

## Architecture

```
Deploy (deploy.ts) ──POST──┐
Systemd OnFailure ──────────┤
App routes (future) ────────┼──> notify service (:9001) ──> Slack webhook
```

## Event types

| Type | Status | Source |
|------|--------|--------|
| `deploy.success` | success | webhook deploy.ts |
| `deploy.failure` | failure | webhook deploy.ts |
| `service.crashed` | failure | systemd OnFailure |
| `health.failure` | failure | webhook deploy.ts |
| `nixos.rebuild.failure` | failure | webhook deploy.ts |

Extensible to app-level events (logins, activity) via `notifyEvent()` helper.

## Files

- `src/notify/` — types, Slack formatter, client helper, Hono service
- `infrastructure/nixos/modules/notify.nix` — systemd service
- `infrastructure/nixos/modules/notify-failure.nix` — OnFailure template unit
- Modified: `flake.nix`, `configuration.nix`, `webhook.nix`, `app.nix`, `homepage.nix`
- Design: `notes/2026-04-11-notify-service/design.md`

## Test plan

- [x] 27 new tests pass (validation, Slack formatting, client, service routes)
- [x] 12 existing webhook deploy tests pass with no regressions
- [x] Full suite: 151 tests pass
- [x] Lint and type check clean
- [ ] After merge: add Slack webhook URL to sops secrets on EC2
- [ ] After merge: verify notifications arrive in Slack channel