### PR TITLE
infra(devshell): add pulumi to flake dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,8 @@
             nodejs_22
             gh
             caddy
+            pulumi
+            pulumiPackages.pulumi-language-nodejs
           ];
 
           shellHook = ''


### PR DESCRIPTION
## Summary

- Adds `pulumi` and `pulumiPackages.pulumi-language-nodejs` to the flake dev shell
- Fixes `bun run cli infra *` and `bun run cli nixos *` commands failing with `ENOENT: pulumi`

## Test plan

- [x] `direnv allow` picks up pulumi
- [x] `pulumi version` works in dev shell