### PR TITLE
infra(deploy): use mktemp for main deploy workdir

### DIFF
--- a/infrastructure/nixos/modules/deploy.nix
+++ b/infrastructure/nixos/modules/deploy.nix
@@ -8,10 +8,14 @@ let
 
     echo "Starting main deployment at $SHA..."
 
-    cd /tmp
-    rm -rf forms-lab-deploy
-    ${pkgs.git}/bin/git clone https://github.com/flexion/forms-lab.git forms-lab-deploy
-    cd forms-lab-deploy
+    # Use a unique working directory per run so a stale or mis-owned
+    # leftover can never wedge the next deploy.
+    WORK_DIR=$(${pkgs.coreutils}/bin/mktemp -d /tmp/forms-lab-deploy.XXXXXX)
+    trap 'rm -rf "$WORK_DIR"' EXIT
+
+    cd "$WORK_DIR"
+    ${pkgs.git}/bin/git clone https://github.com/flexion/forms-lab.git repo
+    cd repo
     ${pkgs.git}/bin/git checkout "$SHA"
 
     # Check if nixos config changed since last deployment

--- a/src/entrypoints/notify/slack.ts
+++ b/src/entrypoints/notify/slack.ts
@@ -7,12 +7,16 @@ const STATUS_COLORS: Record<string, string> = {
 }
 
 export function formatSlackMessage(event: NotifyEvent): object {
+  const titleText = event.url
+    ? `*[${event.type}]* <${event.url}|${event.title}>`
+    : `*[${event.type}]* ${event.title}`
+
   const blocks: object[] = [
     {
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: `*[${event.type}]* ${event.title}`,
+        text: titleText,
       },
     },
   ]

--- a/src/entrypoints/webhook/deploy.ts
+++ b/src/entrypoints/webhook/deploy.ts
@@ -49,9 +49,13 @@ export interface DeployWithStatusOptions {
   hostname?: string
 }
 
-export async function deployMainBranch(sha: string): Promise<DeployResult> {
+export async function deployMainBranch(
+  sha: string,
+  hostname?: string,
+): Promise<DeployResult> {
   const script =
     process.env.DEPLOY_MAIN_SCRIPT || '/srv/forms-lab/deploy-main.sh'
+  const deployedUrl = hostname ? `https://${hostname}/` : undefined
 
   try {
     const proc = Bun.spawn([script, sha], {
@@ -81,6 +85,7 @@ export async function deployMainBranch(sha: string): Promise<DeployResult> {
       type: 'deploy.success',
       title: `Main deployment succeeded at ${sha.slice(0, 7)}`,
       status: 'success',
+      url: deployedUrl,
     })
     return { success: true, stdout, stderr }
   } catch (err) {
@@ -131,12 +136,17 @@ export async function triggerDeployWithStatus(
 
   const result = await triggerDeploy(branch, sha)
 
+  const environmentUrl = hostname
+    ? `https://${hostname}/${safeBranch}/`
+    : undefined
+
   if (result.success) {
     notifyEvent({
       type: 'deploy.success',
       title: `Deployed \`${branch}\` at ${sha.slice(0, 7)}`,
       status: 'success',
       details: result.stdout?.split('\n').pop() || undefined,
+      url: environmentUrl,
     })
   } else {
     notifyEvent({
@@ -150,9 +160,6 @@ export async function triggerDeployWithStatus(
   if (deploymentId) {
     try {
       if (result.success) {
-        const environmentUrl = hostname
-          ? `https://${hostname}/${safeBranch}/`
-          : undefined
         await githubClient.createDeploymentStatus(
           owner,
           repo,

--- a/src/entrypoints/webhook/main.ts
+++ b/src/entrypoints/webhook/main.ts
@@ -73,7 +73,7 @@ app.post('/', async (c) => {
 
   // Handle main branch deployment (includes NixOS config updates)
   if (push.branch === 'main') {
-    deployMainBranch(push.sha).catch((err) => {
+    deployMainBranch(push.sha, hostname).catch((err) => {
       console.error('Main deployment failed:', err)
     })
     return c.json(

--- a/src/services/notifications/types.ts
+++ b/src/services/notifications/types.ts
@@ -6,6 +6,7 @@ export interface NotifyEvent {
   status: NotifyStatus
   details?: string
   timestamp?: string
+  url?: string
 }
 
 const VALID_STATUSES: Set<string> = new Set(['success', 'failure', 'info'])
@@ -46,6 +47,10 @@ export function validateEvent(
 
   if (typeof obj.details === 'string') {
     event.details = obj.details
+  }
+
+  if (typeof obj.url === 'string') {
+    event.url = obj.url
   }
 
   return { valid: true, event }

--- a/test/notify-slack.test.ts
+++ b/test/notify-slack.test.ts
@@ -14,6 +14,7 @@ describe('validateEvent', () => {
       status: 'success',
       details: 'Branch deployed in 42s',
       timestamp: '2026-04-11T12:00:00Z',
+      url: 'https://example.com/',
     })
 
     expect(result.valid).toBe(true)
@@ -23,6 +24,20 @@ describe('validateEvent', () => {
       expect(result.event.status).toBe('success')
       expect(result.event.details).toBe('Branch deployed in 42s')
       expect(result.event.timestamp).toBe('2026-04-11T12:00:00Z')
+      expect(result.event.url).toBe('https://example.com/')
+    }
+  })
+
+  it('omits url when not a string', () => {
+    const result = validateEvent({
+      type: 'x',
+      title: 'y',
+      status: 'info',
+      url: 42,
+    })
+    expect(result.valid).toBe(true)
+    if (result.valid) {
+      expect(result.event.url).toBeUndefined()
     }
   })
 
@@ -167,6 +182,31 @@ describe('formatSlackMessage', () => {
       (b) => b.type === 'context',
     )
     expect(contextBlocks).toHaveLength(2) // details + timestamp
+  })
+
+  it('renders title as mrkdwn link when url present', () => {
+    const msg = formatSlackMessage({
+      ...baseEvent,
+      url: 'https://example.com/main/',
+    }) as {
+      attachments: Array<{
+        blocks: Array<{ type: string; text?: { type: string; text: string } }>
+      }>
+    }
+    const section = msg.attachments[0].blocks.find((b) => b.type === 'section')
+    expect(section?.text?.text).toBe(
+      '*[deploy.success]* <https://example.com/main/|Deployed main>',
+    )
+  })
+
+  it('renders plain title when url absent', () => {
+    const msg = formatSlackMessage(baseEvent) as {
+      attachments: Array<{
+        blocks: Array<{ type: string; text?: { type: string; text: string } }>
+      }>
+    }
+    const section = msg.attachments[0].blocks.find((b) => b.type === 'section')
+    expect(section?.text?.text).toBe('*[deploy.success]* Deployed main')
   })
 })
 

--- a/test/webhook-deploy.test.ts
+++ b/test/webhook-deploy.test.ts
@@ -1,10 +1,38 @@
-import { beforeEach, describe, expect, it } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import {
   deployMainBranch,
   triggerDeploy,
   triggerDeployWithStatus,
 } from '../src/entrypoints/webhook/deploy'
 import type { GitHubClient } from '../src/services/deployment/github'
+import type { NotifyEvent } from '../src/services/notifications/types'
+
+function captureNotifyEvents(): {
+  events: NotifyEvent[]
+  restore: () => void
+} {
+  const events: NotifyEvent[] = []
+  const originalFetch = globalThis.fetch
+  const mockFetch = async (input: unknown, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : String(input)
+    if (url.includes('/event') && init?.body) {
+      try {
+        events.push(JSON.parse(init.body as string) as NotifyEvent)
+      } catch {}
+      return new Response('ok', { status: 200 })
+    }
+    return originalFetch(input as RequestInfo, init)
+  }
+  ;(mockFetch as unknown as { preconnect: (url: string) => void }).preconnect =
+    () => {}
+  globalThis.fetch = mockFetch as typeof fetch
+  return {
+    events,
+    restore: () => {
+      globalThis.fetch = originalFetch
+    },
+  }
+}
 
 describe('triggerDeploy', () => {
   const _originalEnv = process.env.DEPLOY_SCRIPT
@@ -231,5 +259,96 @@ describe('deployMainBranch', () => {
     if (!result.success) {
       expect(result.error).toBeDefined()
     }
+  })
+
+  describe('notify events', () => {
+    let capture: ReturnType<typeof captureNotifyEvents>
+
+    beforeEach(() => {
+      capture = captureNotifyEvents()
+    })
+
+    afterEach(() => {
+      capture.restore()
+      delete process.env.DEPLOY_MAIN_SCRIPT
+    })
+
+    it('includes deployed URL on success when hostname provided', async () => {
+      process.env.DEPLOY_MAIN_SCRIPT = 'true'
+
+      await deployMainBranch('abc123def', 'example.com')
+
+      const event = capture.events.find((e) => e.type === 'deploy.success')
+      expect(event).toBeDefined()
+      expect(event?.url).toBe('https://example.com/')
+    })
+
+    it('omits URL when hostname not provided', async () => {
+      process.env.DEPLOY_MAIN_SCRIPT = 'true'
+
+      await deployMainBranch('abc123def')
+
+      const event = capture.events.find((e) => e.type === 'deploy.success')
+      expect(event).toBeDefined()
+      expect(event?.url).toBeUndefined()
+    })
+
+    it('omits URL on failure', async () => {
+      process.env.DEPLOY_MAIN_SCRIPT = 'false'
+
+      await deployMainBranch('abc123def', 'example.com')
+
+      const event = capture.events.find((e) => e.type === 'deploy.failure')
+      expect(event).toBeDefined()
+      expect(event?.url).toBeUndefined()
+    })
+  })
+})
+
+describe('triggerDeployWithStatus notify events', () => {
+  let capture: ReturnType<typeof captureNotifyEvents>
+
+  beforeEach(() => {
+    process.env.DEPLOY_SCRIPT = 'echo'
+    capture = captureNotifyEvents()
+  })
+
+  afterEach(() => {
+    capture.restore()
+  })
+
+  it('includes deployed URL on successful branch deploy when hostname provided', async () => {
+    const client = createMockGitHubClient()
+
+    await triggerDeployWithStatus({
+      branch: 'feature/test',
+      sha: 'abc123def',
+      owner: 'flexion',
+      repo: 'forms-lab',
+      githubClient: client,
+      hostname: 'example.com',
+    })
+
+    const event = capture.events.find((e) => e.type === 'deploy.success')
+    expect(event).toBeDefined()
+    expect(event?.url).toBe('https://example.com/feature-test/')
+  })
+
+  it('omits URL on branch deploy failure', async () => {
+    process.env.DEPLOY_SCRIPT = 'false'
+    const client = createMockGitHubClient()
+
+    await triggerDeployWithStatus({
+      branch: 'feature/test',
+      sha: 'abc123def',
+      owner: 'flexion',
+      repo: 'forms-lab',
+      githubClient: client,
+      hostname: 'example.com',
+    })
+
+    const event = capture.events.find((e) => e.type === 'deploy.failure')
+    expect(event).toBeDefined()
+    expect(event?.url).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Context

After PR #41 merged, the webhook deploy to main failed with:

```
[deploy.failure] Main deployment failed at 7eabdb5
rm: cannot remove 'forms-lab-deploy/tsconfig.json': Permission denied
rm: cannot remove 'forms-lab-deploy/.stylelintrc.json': Permission denied
rm: cannot remove 'forms-lab-deploy/.git/index': Permission denied
...
```

**Root cause:** `deployMainScript` in `infrastructure/nixos/modules/deploy.nix` used a fixed `/tmp/forms-lab-deploy` path and relied on `rm -rf` to clean it between runs. During manual PR #41 testing the script was run from a root shell on EC2, leaving `/tmp/forms-lab-deploy` owned by `root`. The webhook service runs as `forms-lab` and could not remove root-owned files, so every subsequent deploy hit `Permission denied` on the very first step.

The failure had already been cleared manually on EC2 (stale `/tmp/forms-lab-deploy` removed, `/srv/forms-lab/main` and `/srv/forms-lab/repo.git` and `caddy.d/branch-main.caddy` chowned to `forms-lab`, deploy-main re-run successfully at `7eabdb5`). This PR prevents the class of bug from recurring.

## Changes

### 1. Use mktemp for main deploy workdir
**File:** `infrastructure/nixos/modules/deploy.nix`

- Use `mktemp -d /tmp/forms-lab-deploy.XXXXXX` for a unique working directory per run
- Install an `EXIT` trap that removes the work dir regardless of how the script exits
- Clone into `repo/` inside the work dir instead of a top-level fixed name

Makes the main deploy robust to stale state from any source — manual testing from a different user, interrupted runs, partial failures, etc. Each deploy gets a fresh dir and cleans up after itself.

### 2. Link Slack messages to the deployed URL
**Files:** `src/services/notifications/types.ts`, `src/entrypoints/notify/slack.ts`, `src/entrypoints/webhook/deploy.ts`, `src/entrypoints/webhook/main.ts`, plus tests

- Add optional `url` field to `NotifyEvent` and accept it in `validateEvent`
- `formatSlackMessage` renders the title as an mrkdwn link (`<url|title>`) when `url` is set, otherwise falls back to plain text
- `deployMainBranch(sha, hostname?)` now accepts the webhook's `DEPLOY_HOSTNAME` and sets `url: https://<hostname>/` on success
- `triggerDeployWithStatus` sets `url` to the branch environment URL (`https://<hostname>/<branch>/`) on success — the same URL already passed to GitHub's deployment status
- Failures omit `url` since nothing new is actually reachable there

Successful deploy notifications in Slack are now one click away from the live site. Dashboards, logs, and Slack all agree on the canonical URL.

## Testing

- [x] `bun test` — 436/436 pass
- [x] `bun run --no-warnings tsc --noEmit` clean
- [x] Biome lint clean (src/test/scripts)
- [x] Current main deploy is healthy on EC2 (`curl https://ec2-34-197-222-16.compute-1.amazonaws.com/health` → 200)
- [x] Merge this PR to auto-deploy and verify the new script runs
- [x] Verify `/tmp/forms-lab-deploy.*` dirs are cleaned up after a run
- [x] Verify next Slack deploy notification renders the URL as a clickable link

## Related

- Follow-up to #41