### PR TITLE
infra(deploy): grant forms-lab sudo for rsync and nixos-rebuild

### DIFF
--- a/infrastructure/nixos/configuration.nix
+++ b/infrastructure/nixos/configuration.nix
@@ -72,7 +72,8 @@
     };
   };
 
-  # Allow forms-lab user to manage its own services and reload Caddy
+  # Allow forms-lab user to manage its own services, reload Caddy, and
+  # apply NixOS config changes that arrive via the webhook-driven main deploy.
   security.sudo.extraRules = [{
     users = [ "forms-lab" ];
     commands = [{
@@ -89,6 +90,14 @@
       options = [ "NOPASSWD" ];
     } {
       command = "${pkgs.systemd}/bin/systemctl reload caddy.service";
+      options = [ "NOPASSWD" ];
+    } {
+      command = "${pkgs.rsync}/bin/rsync -av --delete infrastructure/nixos/ /etc/nixos/";
+      options = [ "NOPASSWD" ];
+    } {
+      # Use a wildcard for the flake target because `#` is a comment
+      # character in sudoers and would otherwise truncate the rule.
+      command = "${pkgs.nixos-rebuild}/bin/nixos-rebuild switch --flake /etc/nixos*";
       options = [ "NOPASSWD" ];
     }];
   }];

--- a/infrastructure/nixos/modules/deploy.nix
+++ b/infrastructure/nixos/modules/deploy.nix
@@ -21,8 +21,8 @@ let
     # Check if nixos config changed since last deployment
     if ! ${pkgs.diffutils}/bin/diff -qr infrastructure/nixos /etc/nixos >/dev/null 2>&1; then
       echo "NixOS config changed, rebuilding..."
-      ${pkgs.rsync}/bin/rsync -av infrastructure/nixos/ /etc/nixos/
-      /run/wrappers/bin/sudo nixos-rebuild switch --flake /etc/nixos#forms-lab
+      /run/wrappers/bin/sudo ${pkgs.rsync}/bin/rsync -av --delete infrastructure/nixos/ /etc/nixos/
+      /run/wrappers/bin/sudo ${pkgs.nixos-rebuild}/bin/nixos-rebuild switch --flake /etc/nixos#forms-lab
     else
       echo "No NixOS config changes"
     fi


### PR DESCRIPTION
## Context

After PR #45 merged, the main deploy failed again, but with a different error than before:

```
[deploy.failure] Main deployment failed at 9782a37
rsync: [generator] chgrp "/etc/nixos/." failed: Operation not permitted (1)
rsync: [receiver] mkstemp "/etc/nixos/.configuration.nix.2DY3om" failed: Permission denied (13)
...
rsync: [receiver] mkstemp "/etc/nixos/modules/.webhook.nix.mzOwfS" failed: Permission denied (13)
rsync error: some files/attrs were not transferred (see previous errors) (code 23)
```

## Root cause

The main deploy script does:

```sh
if ! diff -qr infrastructure/nixos /etc/nixos; then
  rsync -av infrastructure/nixos/ /etc/nixos/
  sudo nixos-rebuild switch --flake /etc/nixos#forms-lab
fi
```

Both branches of this logic require root — `/etc/nixos` is owned by root, and `nixos-rebuild switch` is privileged. But the webhook service runs as `forms-lab`, and its sudo grants only cover `systemctl restart|start|stop forms-lab-app@*`, `systemctl restart forms-lab-homepage.service`, and `systemctl reload caddy.service`. Neither `rsync` nor `nixos-rebuild` is granted.

This code path had never actually worked in production. Every prior deploy happened to have no NixOS config changes, so `diff -qr` short-circuited the broken branch. PR #45 was the first webhook-driven deploy that actually modified `infrastructure/nixos`, which is what exposed the latent bug.

## Changes

### `infrastructure/nixos/configuration.nix`
Add two `NOPASSWD` sudo grants for `forms-lab`:

- `${pkgs.rsync}/bin/rsync -av --delete infrastructure/nixos/ /etc/nixos/`
- `${pkgs.nixos-rebuild}/bin/nixos-rebuild switch --flake /etc/nixos*`

The rebuild rule uses a trailing wildcard because `#` is the sudoers comment character, so `--flake /etc/nixos#forms-lab` would otherwise be truncated at `/etc/nixos` and the rule would not match the real invocation. Verified by reading the generated `/etc/sudoers` before and after the wildcard fix.

### `infrastructure/nixos/modules/deploy.nix`
- Prefix the `rsync` call with `/run/wrappers/bin/sudo` so it actually runs as root.
- Invoke `nixos-rebuild` via its full nix store path (`${pkgs.nixos-rebuild}/bin/nixos-rebuild`) so the command text matches the sudoers rule exactly.
- Add `--delete` to `rsync` so files removed from `infrastructure/nixos/` in a commit also get removed from `/etc/nixos/`.

## Testing

- [x] Manually rsync'd this branch's `infrastructure/nixos/` to `/etc/nixos/` on EC2
- [x] `nixos-rebuild switch --flake /etc/nixos#forms-lab` succeeded
- [x] Verified sudo grants are active: `sudo -u forms-lab sudo -n nixos-rebuild ...` no longer prompts for password (confirms the wildcard/comment fix)
- [x] `bun test` — 436/436 pass
- [x] `tsc --noEmit` clean, Biome clean
- [ ] Merge to verify the next webhook-driven main deploy completes end-to-end

## Deployment notes

EC2 `/etc/nixos` has already been updated by hand to match this branch. When this PR merges, the webhook-triggered deploy of the merge commit will find `infrastructure/nixos/` identical to `/etc/nixos/` and skip the rsync+rebuild step, then proceed to deploy the worktree. No manual step required after merge.

## Related

- Follow-up to #45
- Exposes and fixes a latent bug that predates #41