### PR TITLE
infra(deploy): use full paths in deploy-main script

### DIFF
--- a/infrastructure/nixos/modules/deploy.nix
+++ b/infrastructure/nixos/modules/deploy.nix
@@ -11,7 +11,7 @@ let
     # Use a unique working directory per run so a stale or mis-owned
     # leftover can never wedge the next deploy.
     WORK_DIR=$(${pkgs.coreutils}/bin/mktemp -d /tmp/forms-lab-deploy.XXXXXX)
-    trap 'rm -rf "$WORK_DIR"' EXIT
+    trap '${pkgs.coreutils}/bin/rm -rf "$WORK_DIR"' EXIT
 
     cd "$WORK_DIR"
     ${pkgs.git}/bin/git clone https://github.com/flexion/forms-lab.git repo
@@ -28,10 +28,10 @@ let
     fi
 
     # Deploy main branch app via the standard deploy script
-    forms-lab-deploy main "$SHA"
+    ${deployScript}/bin/forms-lab-deploy main "$SHA"
 
     # Health check
-    sleep 2
+    ${pkgs.coreutils}/bin/sleep 2
     ${pkgs.curl}/bin/curl -f http://localhost:3000/health || exit 1
 
     echo "Main deployment complete"


### PR DESCRIPTION
## Context

After PR #46 merged, the main deploy cleared the sudo/rsync bug and got further — but hit a new error:

```
[deploy.failure] Main deployment failed at df4d51f
/srv/forms-lab/deploy-main.sh: line 28: forms-lab-deploy: command not found
```

## Root cause

`deployMainScript` in `infrastructure/nixos/modules/deploy.nix` invoked three commands by bare name:

- `forms-lab-deploy main "$SHA"` on the "deploy the app" line
- `sleep 2` before the health check
- `rm -rf "$WORK_DIR"` in the `EXIT` trap

The webhook systemd service sets `path = [ git openssh bun ]` explicitly. That PATH doesn't include `coreutils` or the deploy scripts' `environment.systemPackages` entries, so bare-name lookups fail inside the webhook context.

Earlier manual test runs happened to work because I ran the script via `sudo -u forms-lab`, which inherits a broader PATH from the invoking root shell that does include `/run/current-system/sw/bin`. That masked the bug until the real webhook path exercised the code.

## Changes

**File:** `infrastructure/nixos/modules/deploy.nix`

- Call the app deploy script via `${deployScript}/bin/forms-lab-deploy` — a forward reference into the same `let` block, which works because Nix bindings are mutually recursive.
- Use `${pkgs.coreutils}/bin/sleep` before the health check.
- Use `${pkgs.coreutils}/bin/rm` in the `EXIT` trap.

No new sudo grants required — the rsync/nixos-rebuild rules from #46 are unchanged.

## Testing

- [x] Manually rsync'd this branch's `infrastructure/nixos/` to `/etc/nixos/` on EC2 and rebuilt
- [x] Ran `/srv/forms-lab/deploy.sh main df4d51f` to fast-forward the live site to the current main tip (5/5 smoke checks pass)
- [x] https://ec2-34-197-222-16.compute-1.amazonaws.com/health returns 200
- [x] `bun test` — 436/436 pass; `tsc` clean; biome clean
- [ ] Merge to verify next webhook-driven main deploy completes end-to-end via deploy-main

## Deployment notes

EC2 `/etc/nixos` already matches this branch. The webhook-triggered deploy of the merge commit will find no NixOS diff, skip rsync+rebuild, and proceed to `${deployScript}/bin/forms-lab-deploy main <SHA>` — which is the new working invocation.

## Related

- Follow-up to #46 (which exposed this by making the full main-deploy path reachable for the first time)
- Third in the series starting from #41