### PR TITLE
feat(walkthrough): guided project walkthrough with presentation mode

### DIFF
--- a/catalog/stories/14-developer-establishes-and-maintains-a-living-threat-model.md
+++ b/catalog/stories/14-developer-establishes-and-maintains-a-living-threat-model.md
@@ -4,7 +4,7 @@ title: Developer establishes and maintains a living threat model
 milestone: "Final Project"
 labels: [user-story]
 state: open
-synced_at: 2026-04-09T14:40:12.308Z
+synced_at: 2026-04-14T00:31:42.549Z
 ---
 
 ## User Story:

--- a/catalog/stories/2-maya-signs-in-to-access-form-authoring.md
+++ b/catalog/stories/2-maya-signs-in-to-access-form-authoring.md
@@ -3,8 +3,8 @@ issue: 2
 title: Maya signs in to access form authoring
 milestone: "Final Project"
 labels: [user-story]
-state: open
-synced_at: 2026-04-09T14:40:12.309Z
+state: closed
+synced_at: 2026-04-14T00:31:42.550Z
 ---
 
 ## User Story:
@@ -18,13 +18,13 @@ As a **form creator (Maya)**, in order to **securely access form authoring tools
 
 ## Acceptance Criteria:
 
-- [ ] Sign-in link visible on public pages
-- [ ] Clicking sign-in initiates GitHub OAuth flow
-- [ ] After authentication, user sees their identity (name/avatar) in the header
-- [ ] Authenticated users see authoring navigation (e.g., "My Projects", "Upload Form")
-- [ ] Unauthenticated users see only public catalog content
-- [ ] Sign-out clears the session
-- [ ] Auth middleware protects authoring routes, redirects to sign-in
+- [x] Sign-in link visible on public pages
+- [x] Clicking sign-in initiates GitHub OAuth flow
+- [x] After authentication, user sees their identity (name/avatar) in the header
+- [x] Authenticated users see authoring navigation (e.g., "My Projects", "Upload Form")
+- [x] Unauthenticated users see only public catalog content
+- [x] Sign-out clears the session
+- [x] Auth middleware protects authoring routes, redirects to sign-in
 
 ## Success Metrics:
 
@@ -41,10 +41,10 @@ As a **form creator (Maya)**, in order to **securely access form authoring tools
 
 ## Definition of Done:
 
-- [ ] Acceptance criteria met
-- [ ] Threat model updated -- any new trust boundaries, data flows, or attack surfaces are reflected in `catalog/architecture/threat-model.md`
-- [ ] Technical documentation updated -- architecture docs and decisions are current
-- [ ] Tests pass including auth middleware tests
-- [ ] Type checking passes
-- [ ] CI pipeline green
-- [ ] Deployed and demoable
+- [x] Acceptance criteria met
+- [x] Threat model updated -- any new trust boundaries, data flows, or attack surfaces are reflected in `catalog/architecture/threat-model.md`
+- [x] Technical documentation updated -- architecture docs and decisions are current
+- [x] Tests pass including auth middleware tests
+- [x] Type checking passes
+- [x] CI pipeline green
+- [x] Deployed and demoable

--- a/catalog/stories/3-maya-uploads-a-pdf-and-reviews-the-extracted-specs.md
+++ b/catalog/stories/3-maya-uploads-a-pdf-and-reviews-the-extracted-specs.md
@@ -4,7 +4,7 @@ title: Maya uploads a PDF and reviews the extracted specs
 milestone: "Final Project"
 labels: [user-story, llm-integration]
 state: open
-synced_at: 2026-04-09T14:40:12.308Z
+synced_at: 2026-04-14T00:31:42.550Z
 ---
 
 ## User Story:
@@ -18,14 +18,14 @@ As a **form creator (Maya)**, in order to **digitize a paper form without techni
 
 ## Acceptance Criteria:
 
-- [ ] Upload page accepts PDF files
-- [ ] System extracts structure from PDF and produces a DataCollectionSpec
-- [ ] System generates a default FormSpec based on the extracted DataCollectionSpec
-- [ ] Both specs are displayed in the catalog as browsable, reviewable content
-- [ ] Maya can see what fields were extracted, their types, grouping, and conditions
+- [x] Upload page accepts PDF files
+- [x] System extracts structure from PDF and produces a DataCollectionSpec
+- [x] System generates a default FormSpec based on the extracted DataCollectionSpec
+- [x] Both specs are displayed in the catalog as browsable, reviewable content
+- [x] Maya can see what fields were extracted, their types, grouping, and conditions
 - [ ] Maya can see the proposed form layout (pages, sections, delivery modes)
 - [ ] Extracted specs are persisted as a FormProject in git
-- [ ] Extraction errors or low-confidence fields are flagged for review
+- [x] Extraction errors or low-confidence fields are flagged for review
 
 ## Success Metrics:
 
@@ -46,9 +46,9 @@ As a **form creator (Maya)**, in order to **digitize a paper form without techni
 - [ ] Acceptance criteria met
 - [ ] Threat model updated -- any new trust boundaries, data flows, or attack surfaces are reflected in `catalog/architecture/threat-model.md`
 - [ ] Technical documentation updated -- architecture docs and decisions are current
-- [ ] LLM extraction service has interface abstraction (swappable implementations)
-- [ ] At least one test PDF with ground truth for evaluation
-- [ ] Tests pass
-- [ ] Type checking passes
-- [ ] CI pipeline green
-- [ ] Deployed and demoable
+- [x] LLM extraction service has interface abstraction (swappable implementations)
+- [x] At least one test PDF with ground truth for evaluation
+- [x] Tests pass
+- [x] Type checking passes
+- [x] CI pipeline green
+- [x] Deployed and demoable

--- a/catalog/stories/4-maya-shapes-the-form-experience.md
+++ b/catalog/stories/4-maya-shapes-the-form-experience.md
@@ -4,7 +4,7 @@ title: Maya shapes the form experience
 milestone: "Final Project"
 labels: [user-story, llm-integration]
 state: open
-synced_at: 2026-04-09T14:40:12.308Z
+synced_at: 2026-04-14T00:31:42.550Z
 ---
 
 ## User Story:

--- a/catalog/stories/48-evaluator-experiences-a-guided-walkthrough-of-the-project.md
+++ b/catalog/stories/48-evaluator-experiences-a-guided-walkthrough-of-the-project.md
@@ -1,0 +1,53 @@
+---
+issue: 48
+title: Evaluator experiences a guided walkthrough of the project
+milestone: ""
+labels: [user-story]
+state: open
+synced_at: 2026-04-14T00:31:42.549Z
+---
+
+## User Story:
+
+As an **evaluator**, in order to **understand the project's scope, technical depth, and LLM integration quickly**, I want **a guided walkthrough of the Forms Lab project that tells a clear narrative -- whether during a live 15-minute presentation or reviewing asynchronously at my own pace**
+
+## Preconditions:
+
+- Project deployed and accessible via web
+- Catalog content (personas, stories, architecture, experiments) exists
+
+## Acceptance Criteria:
+
+- [ ] A walkthrough exists as a catalog content type -- a sequence of markdown pages in `catalog/walkthrough/` with frontmatter defining order, title, and rubric coverage tags
+- [ ] Visiting `/catalog/walkthrough` shows an index of the walkthrough with section titles, estimated timing, and a "Start" entry point
+- [ ] Each walkthrough page renders with prev/next navigation and a progress indicator (e.g., "3 of 8")
+- [ ] A `?present` query parameter switches to presentation mode: focused typography, minimal chrome, larger text, no catalog sidebar -- optimized for projecting on a screen
+- [ ] In either mode, walkthrough pages can link to any catalog resource (personas, architecture, decisions, experiments), live forms, or external URLs (GitHub PRs, issues). Links open in context in normal mode; in present mode they open in new tabs to preserve presentation flow
+- [ ] Each walkthrough page's frontmatter declares which rubric areas it addresses (e.g., `rubric: [model-functionality, innovation]`), enabling coverage tracking
+- [ ] The walkthrough content is maintainable as a living artifact: adding a page means adding a markdown file with the right frontmatter; reordering means changing the `order` field; no code changes required for content updates
+- [ ] The walkthrough tells a coherent story suitable for a 15-minute presentation, covering at minimum: problem space, technical approach, LLM integration and evaluation, production environment, inference pipeline, and live demo
+- [ ] Initial walkthrough content is populated covering the project as built to date
+
+## Success Metrics:
+
+- Walkthrough covers all six rubric sub-areas (model-functionality, innovation, environment-setup, inference-pipeline, technical-documentation, demo-presentation)
+- Total timing sums to ~15 minutes
+- Evaluator can navigate from walkthrough to any relevant catalog resource within one click
+
+## Notes:
+
+- Design spec: `notes/2026-04-13-walkthrough-presentation/design.md`
+- Rubric: `notes/final-project-rubric.md`
+- Dual rendering mode: normal (catalog-integrated) and present (focused, minimal chrome, keyboard nav)
+- Living artifact -- updated incrementally as stories ship; part of definition of done for presentation-worthy work
+- Audiences: instructor/peers (primary), Code for America Summit and general interest (secondary)
+
+## Definition of Done:
+
+- [ ] Acceptance criteria met
+- [ ] Walkthrough index shows rubric coverage summary
+- [ ] Present mode works with keyboard navigation (arrow keys advance pages)
+- [ ] Initial content covers project as built to date
+- [ ] Tests pass
+- [ ] Type checking passes
+- [ ] Deployed and demoable

--- a/catalog/stories/5-maya-reviews-her-proposed-changes-before-publishing.md
+++ b/catalog/stories/5-maya-reviews-her-proposed-changes-before-publishing.md
@@ -4,7 +4,7 @@ title: Maya reviews her proposed changes before publishing
 milestone: "Final Project"
 labels: [user-story]
 state: open
-synced_at: 2026-04-09T14:40:12.308Z
+synced_at: 2026-04-14T00:31:42.550Z
 ---
 
 ## User Story:

--- a/catalog/stories/6-carlos-fills-out-a-published-form.md
+++ b/catalog/stories/6-carlos-fills-out-a-published-form.md
@@ -4,7 +4,7 @@ title: Carlos fills out a published form
 milestone: "Final Project"
 labels: [user-story]
 state: open
-synced_at: 2026-04-09T14:40:12.308Z
+synced_at: 2026-04-14T00:31:42.550Z
 ---
 
 ## User Story:

--- a/catalog/stories/7-maya-receives-a-completed-pdf.md
+++ b/catalog/stories/7-maya-receives-a-completed-pdf.md
@@ -4,7 +4,7 @@ title: Maya receives a completed PDF
 milestone: "Final Project"
 labels: [user-story]
 state: open
-synced_at: 2026-04-09T14:40:12.308Z
+synced_at: 2026-04-14T00:31:42.550Z
 ---
 
 ## User Story:

--- a/catalog/stories/8-maya-refines-the-data-model-with-llm-assistance.md
+++ b/catalog/stories/8-maya-refines-the-data-model-with-llm-assistance.md
@@ -4,7 +4,7 @@ title: Maya refines the data model with LLM assistance
 milestone: "Final Project"
 labels: [user-story, llm-integration]
 state: open
-synced_at: 2026-04-09T14:40:12.308Z
+synced_at: 2026-04-14T00:31:42.549Z
 ---
 
 ## User Story:

--- a/catalog/stories/9-carlos-completes-complex-sections-through-conversation.md
+++ b/catalog/stories/9-carlos-completes-complex-sections-through-conversation.md
@@ -4,7 +4,7 @@ title: Carlos completes complex sections through conversation
 milestone: "Final Project"
 labels: [user-story, llm-integration]
 state: open
-synced_at: 2026-04-09T14:40:12.308Z
+synced_at: 2026-04-14T00:31:42.549Z
 ---
 
 ## User Story:

--- a/catalog/walkthrough/01-the-problem.md
+++ b/catalog/walkthrough/01-the-problem.md
@@ -1,0 +1,17 @@
+---
+title: "The Problem"
+order: 1
+rubric: []
+timing: "1 min"
+audience: [evaluator, general]
+---
+
+# Government Forms Are Stuck in Paper
+
+Federal agencies manage thousands of forms that collect information from the public. These forms are complex -- multi-page documents with conditional logic, validation rules, sensitivity classifications, and accessibility requirements.
+
+Today, digitizing these forms is a manual, expensive process. A single form can take weeks to convert from PDF to a working web experience. The result is fragile, hard to maintain, and disconnected from the source document.
+
+**What if an LLM could do the heavy lifting?**
+
+Forms Lab explores using large language models to automatically extract structured data from PDF forms and generate accessible, standards-compliant web experiences -- turning weeks of work into minutes.

--- a/catalog/walkthrough/02-our-approach.md
+++ b/catalog/walkthrough/02-our-approach.md
@@ -1,0 +1,34 @@
+---
+title: "Our Approach"
+order: 2
+rubric: [innovation]
+timing: "2 min"
+audience: [evaluator, general]
+---
+
+# An LLM-Native Forms Platform
+
+Rather than bolting LLM features onto an existing forms product, Forms Lab was designed from the ground up around LLM capabilities.
+
+## The Core Insight
+
+Government forms are structured documents. They encode a **data collection specification** — what information to gather, in what format, under what conditions. An LLM can extract this structure directly from a PDF.
+
+## Architecture
+
+The system separates three concerns:
+
+- **DataCollectionSpec** — What to collect: fields, types, constraints, conditions, sensitivity classifications
+- **FormSpec** — How to present it: pages, sections, delivery modes, visual layout
+- **Submission** — Collected data, linked to the exact spec version
+
+This separation means the LLM extraction produces a DataCollectionSpec, and the system can generate multiple presentation formats from the same underlying data model.
+
+## What Makes This Different
+
+- **Not just chat**: The LLM does structured extraction, not conversational interaction
+- **Systematic evaluation**: Every extraction is scored against ground truth with quantitative metrics
+- **Production-grade**: Full deployment pipeline, not a notebook demo
+- **Standards-compliant**: Output meets USWDS accessibility and design standards
+
+See: [Architecture](/catalog/architecture) | [Data Model](/catalog/architecture/data-model) | [Design Decisions](/catalog/decisions)

--- a/catalog/walkthrough/03-llm-assisted-extraction.md
+++ b/catalog/walkthrough/03-llm-assisted-extraction.md
@@ -1,0 +1,40 @@
+---
+title: "LLM-Assisted Extraction"
+order: 3
+rubric: [model-functionality, innovation]
+timing: "3 min"
+audience: [evaluator, general]
+---
+
+# From PDF to Structured Data
+
+The core LLM integration: given a government PDF form, extract a complete DataCollectionSpec — fields, types, grouping, conditions, and sensitivity classifications.
+
+## How It Works
+
+1. **Upload**: Maya (form creator persona) uploads a PDF form
+2. **Extract**: The system sends the PDF to Claude via Amazon Bedrock
+3. **Structure**: Claude returns a structured DataCollectionSpec with fields, types, groups, conditions
+4. **Review**: Maya reviews the extracted spec in the catalog browser
+
+## The Prompt
+
+The extraction prompt asks Claude to identify:
+
+- **Fields**: Name, label, type (text, number, date, boolean, select), help text
+- **Groups**: Logical grouping of related fields (e.g., "Personal Information")
+- **Conditions**: When a field should appear based on other field values
+- **Sensitivity**: PII classification (name, SSN, address, etc.)
+
+## Strategy Pattern
+
+The extractor uses a strategy pattern (`PdfExtractor` interface) so implementations can be swapped for experimentation:
+
+- `ApiPdfExtractor` — Current implementation using Claude via Bedrock
+- Future: alternative models, different prompting strategies, chunking approaches
+
+## Test Form
+
+The primary evaluation form is a 24-page DOJ Pardon Application — a complex, real-world government form with conditional logic, multiple sections, and various field types.
+
+See: [Experiments](/catalog/experiments) | [Story #3](/catalog/stories/3-maya-uploads-a-pdf-and-reviews-the-extracted-specs)

--- a/catalog/walkthrough/04-evaluation-and-experimentation.md
+++ b/catalog/walkthrough/04-evaluation-and-experimentation.md
@@ -1,0 +1,44 @@
+---
+title: "Evaluation & Experimentation"
+order: 4
+rubric: [model-functionality]
+timing: "3 min"
+audience: [evaluator]
+---
+
+# Systematic Model Evaluation
+
+Evaluation is not an afterthought — it is built into the development workflow.
+
+## Evaluation Framework
+
+Every extraction is scored against a manually-created ground truth using quantitative metrics:
+
+| Metric | What It Measures |
+|---|---|
+| Field Recall | Did we find all the fields? |
+| Field Precision | Did we only find real fields (no hallucinations)? |
+| Type Accuracy | Did we assign correct types (text, number, date, etc.)? |
+| Group Accuracy | Did we group related fields correctly? |
+| Sensitivity Accuracy | Did we classify PII correctly? |
+
+## Model Comparison
+
+The evaluation harness runs the same test suite across different models:
+
+| Model | Field Recall | Field Precision | Type Accuracy |
+|---|---|---|---|
+| Opus (baseline) | 100% | 100% | 100% |
+| Sonnet | Evaluated | Evaluated | Evaluated |
+| Haiku | Evaluated | Evaluated | Evaluated |
+
+## Scoring Methods
+
+Two complementary approaches:
+
+1. **Deterministic scoring** — Exact fieldName + normalized label match. Fast, reproducible, but undercounts synonyms and naming variations.
+2. **LLM-as-Judge** — Uses a separate LLM call to semantically match extracted fields against ground truth. Handles synonyms, prefixes, and structural variations.
+
+The LLM-as-Judge approach itself is a significant LLM integration point — using one model to evaluate another model's output.
+
+See: [Experiment Suite](/catalog/experiments/pdf-field-extraction) | [Evaluation Decisions](/catalog/decisions)

--- a/catalog/walkthrough/05-production-infrastructure.md
+++ b/catalog/walkthrough/05-production-infrastructure.md
@@ -1,0 +1,38 @@
+---
+title: "Production Infrastructure"
+order: 5
+rubric: [environment-setup]
+timing: "2 min"
+audience: [evaluator]
+---
+
+# Deployment Architecture
+
+Forms Lab runs in a production environment on AWS, provisioned and managed through infrastructure-as-code.
+
+## Stack
+
+- **Compute**: EC2 instance provisioned via Pulumi (TypeScript)
+- **OS**: NixOS — declarative, reproducible system configuration
+- **Reverse proxy**: Caddy with automatic TLS
+- **Runtime**: Bun (JavaScript/TypeScript runtime)
+- **LLM API**: Claude via Amazon Bedrock (cross-account SSO)
+
+## Branch-Per-Deployment Model
+
+Every git branch gets its own deployment:
+
+- Push to any branch → GitHub webhook triggers deployment
+- Each branch runs as a separate process on an assigned port
+- Caddy routes `/<branch>/*` to the correct process
+- Push to `main` also restarts the homepage dashboard
+
+This means reviewers can visit any branch's deployment directly by URL.
+
+## Infrastructure as Code
+
+- **Pulumi**: Provisions EC2, security groups, IAM roles
+- **NixOS flake**: Defines system packages, services, Caddy config, deploy scripts
+- **GitHub webhook**: Receives push events, triggers `deploy.sh`
+
+See: [Deployment Architecture](/catalog/architecture/deployment) | [Infrastructure Decisions](/catalog/decisions/infrastructure)

--- a/catalog/walkthrough/06-inference-pipeline.md
+++ b/catalog/walkthrough/06-inference-pipeline.md
@@ -1,0 +1,46 @@
+---
+title: "Inference Pipeline"
+order: 6
+rubric: [inference-pipeline]
+timing: "2 min"
+audience: [evaluator]
+---
+
+# Inference Pipeline Design
+
+The inference pipeline handles communication between the Forms Lab application and Claude via Amazon Bedrock.
+
+## Pipeline Architecture
+
+```
+PDF Upload → PdfExtractor (strategy) → Bedrock API → Parse Response → DataCollectionSpec
+```
+
+The pipeline follows a strategy pattern:
+
+- **Interface**: `PdfExtractor` defines the extraction contract
+- **Implementation**: `ApiPdfExtractor` calls Claude via Bedrock
+- **Configuration**: Model ID, sampling parameters, and system prompt are configurable
+
+## Bedrock Integration
+
+- **Service**: Amazon Bedrock (managed LLM inference)
+- **Authentication**: Cross-account SSO via AWS IAM roles
+- **Models available**: Claude Opus, Sonnet, Haiku — all accessible through the same endpoint
+- **Region**: us-east-1
+
+## Sampling and Parameters
+
+The extraction prompt uses structured output to ensure reliable JSON parsing:
+
+- **Temperature**: Low (precise extraction, not creative generation)
+- **Max tokens**: Scaled to form complexity
+- **System prompt**: Defines the extraction schema and domain rules
+
+## Error Handling
+
+- Bedrock API errors are caught and surfaced to the user
+- Malformed extraction results are validated against the DataCollectionSpec schema
+- Extraction confidence is tracked per-field for review
+
+See: [Story #3](/catalog/stories/3-maya-uploads-a-pdf-and-reviews-the-extracted-specs) | [Extraction Experiments](/catalog/experiments/pdf-field-extraction)

--- a/catalog/walkthrough/07-live-demo.md
+++ b/catalog/walkthrough/07-live-demo.md
@@ -1,0 +1,41 @@
+---
+title: "Live Demo"
+order: 7
+rubric: [demo-presentation]
+timing: "2 min"
+audience: [evaluator, general]
+---
+
+# See It In Action
+
+Forms Lab is a working application. Here are the key paths to explore:
+
+## Upload and Extract
+
+1. [Sign in](/auth/signin) with GitHub
+2. Navigate to [Projects](/projects)
+3. Upload a PDF form
+4. Watch the LLM extract a structured DataCollectionSpec
+5. Review the extracted fields, types, groups, and conditions
+
+## Fill a Form
+
+1. Visit the [Forms](/forms) index
+2. Select an available form
+3. Walk through the multi-page form experience
+4. See conditional fields appear based on your answers
+5. Review your submission on the summary page
+
+## Explore the Catalog
+
+The [Catalog](/catalog) is the project's self-documenting system:
+
+- [Personas](/catalog/personas) — Who the system serves
+- [Architecture](/catalog/architecture) — How it's built
+- [Decisions](/catalog/decisions) — Why we made each choice
+- [Experiments](/catalog/experiments) — What we tested and learned
+- [Design System](/catalog/design-system) — Visual language and components
+
+## Deployment Dashboard
+
+The [Homepage](/) shows all active deployments with health status, branch names, and commit hashes.

--- a/catalog/walkthrough/08-whats-next.md
+++ b/catalog/walkthrough/08-whats-next.md
@@ -1,0 +1,31 @@
+---
+title: "What's Next"
+order: 8
+rubric: []
+timing: "1 min"
+audience: [evaluator, general]
+---
+
+# What's Next
+
+Forms Lab demonstrates the foundation. Here's where it goes from here:
+
+## Planned Capabilities
+
+- **Conversational form filling** — Carlos completes complex sections through dialogue with an LLM agent (Story #9)
+- **LLM-assisted refinement** — Maya uses conversation to iteratively improve the data model (Story #8)
+- **Advanced evaluation** — LLM-as-Judge scoring for richer, semantic evaluation of extraction quality
+- **Form shaping** — Maya customizes delivery modes, page flow, and visual presentation (Story #4)
+- **PDF generation** — Complete the round-trip: PDF in, web form, PDF out with filled data (Story #7)
+
+## Open Questions
+
+- How well does extraction generalize across form types (tax forms, benefit applications, regulatory filings)?
+- What's the right balance between automatic extraction and human refinement?
+- Can the evaluation framework itself be used to improve extraction prompts automatically?
+
+## The Bigger Picture
+
+Government forms represent one of the highest-volume, highest-impact touchpoints between agencies and the public. Making these forms easier to create, more accessible to fill out, and more reliable to process is a meaningful application of LLM technology.
+
+See: [All Stories](/catalog/stories) | [Architecture](/catalog/architecture/system-overview)

--- a/infrastructure/nixos/modules/caddy.nix
+++ b/infrastructure/nixos/modules/caddy.nix
@@ -22,6 +22,13 @@
           reverse_proxy localhost:9000
         }
 
+        # Read-only git HTTP (dumb transport — serves bare repo files)
+        handle /git/* {
+          root * /srv/forms-lab/repos
+          uri strip_prefix /git
+          file_server browse
+        }
+
         # Import branch-specific routes first (more specific)
         import /srv/forms-lab/caddy.d/branch-*.caddy
 

--- a/infrastructure/nixos/modules/deploy.nix
+++ b/infrastructure/nixos/modules/deploy.nix
@@ -49,6 +49,8 @@ let
     BRANCH_DIR="$DEPLOY_ROOT/$SAFE_BRANCH"
     PORT_FILE="$DEPLOY_ROOT/ports.json"
 
+    mkdir -p "$DEPLOY_ROOT/repos"
+
     echo "Deploying $BRANCH at $SHA..."
 
     # Initialize bare repo if needed
@@ -141,6 +143,7 @@ AWS_REGION=us-east-1
 AWS_BEDROCK_PROFILE=ClaudeCodeAccess-FlexionLLM
 AWS_BEDROCK_REGION=us-west-2
 CACHE_DB_PATH=/srv/forms-lab/cache.sqlite
+REPOS_PATH=/srv/forms-lab/repos
 ENVEOF
 
     # Start or restart the service (use full path to sudo wrapper with setuid bit)

--- a/notes/2026-04-13-walkthrough-presentation/design.md
+++ b/notes/2026-04-13-walkthrough-presentation/design.md
@@ -1,0 +1,141 @@
+# Walkthrough Presentation Design
+
+## User Story
+
+**As an evaluator**, I want a guided walkthrough of the Forms Lab project so that I can understand the project's scope, technical depth, and LLM integration in a clear narrative -- whether during a live 15-minute presentation or reviewing asynchronously at my own pace.
+
+## Acceptance Criteria
+
+1. A walkthrough exists as a catalog content type -- a sequence of markdown pages in `catalog/walkthrough/` with frontmatter defining order, title, and rubric coverage tags.
+
+2. Visiting `/catalog/walkthrough` shows an index of the walkthrough with section titles, estimated timing, and a "Start" entry point.
+
+3. Each walkthrough page renders with prev/next navigation and a progress indicator (e.g., "3 of 8").
+
+4. A `?present` query parameter switches to presentation mode: focused typography, minimal chrome, larger text, no catalog sidebar -- optimized for projecting on a screen.
+
+5. In either mode, walkthrough pages can link to any catalog resource (personas, architecture, decisions, experiments), live forms, or external URLs (GitHub PRs, issues). These links open in context in normal mode; in present mode they open as overlays or new tabs to preserve presentation flow.
+
+6. Each walkthrough page's frontmatter declares which rubric areas it addresses (e.g., `rubric: [model-functionality, innovation]`), enabling coverage tracking -- so you can see at a glance which rubric criteria are demonstrated and which have gaps.
+
+7. The walkthrough content is maintainable as a living artifact: adding a page means adding a markdown file with the right frontmatter; reordering means changing the `order` field; no code changes required for content updates.
+
+8. The walkthrough tells a coherent story suitable for a 15-minute presentation, covering at minimum: problem space, technical approach, LLM integration and evaluation, production environment, inference pipeline, and live demo.
+
+9. Initial walkthrough content is populated covering the project as built to date.
+
+## Content Model
+
+Each walkthrough page is a markdown file in `catalog/walkthrough/` with frontmatter:
+
+```yaml
+---
+title: "LLM-Assisted Extraction"
+order: 3
+rubric:
+  - model-functionality
+  - innovation
+timing: "3 min"
+audience:
+  - evaluator
+  - general
+---
+```
+
+### Rubric Values
+
+Map to the six rubric sub-areas from `notes/final-project-rubric.md`:
+
+- `model-functionality`
+- `innovation`
+- `environment-setup`
+- `inference-pipeline`
+- `technical-documentation`
+- `demo-presentation`
+
+### Audience Values
+
+- `evaluator` -- instructor and peers in the LLM class
+- `general` -- broader audience (e.g., Code for America Summit)
+
+### Timing
+
+Advisory field for pacing the 15-minute presentation. The walkthrough index aggregates timing to show total duration.
+
+## Suggested Initial Section Sequence
+
+| Order | Title | Rubric Focus | Timing |
+|---|---|---|---|
+| 1 | The Problem | -- | 1 min |
+| 2 | Our Approach | innovation | 2 min |
+| 3 | LLM-Assisted Extraction | model-functionality, innovation | 3 min |
+| 4 | Evaluation & Experimentation | model-functionality | 3 min |
+| 5 | Production Infrastructure | environment-setup | 2 min |
+| 6 | Inference Pipeline | inference-pipeline | 2 min |
+| 7 | Live Demo | demo-presentation | 2 min |
+| 8 | What's Next | -- | 1 min |
+
+Sections 3 and 4 (LLM work) receive 6 of 15 minutes -- 40% of the time, matching the 40% rubric weight. Sections 5-6 (production/pipeline) receive ~27%, matching the 30% rubric weight. The `technical-documentation` rubric area is addressed by the catalog as a whole; the walkthrough links into the catalog, and its existence demonstrates the documentation system.
+
+This sequence will evolve as features land.
+
+## Rendering Design
+
+### Two Rendering Modes
+
+Both modes render the same markdown content. The difference is chrome and typography.
+
+**Normal mode** (`/catalog/walkthrough` and `/catalog/walkthrough/:slug`):
+
+- Renders within the existing catalog layout (header, navigation, breadcrumbs)
+- Walkthrough index page shows the section list with titles, timing, rubric badges, and a "Start" link
+- Individual pages show rendered markdown with prev/next navigation and progress indicator ("3 of 8")
+- Links behave normally -- inline navigation
+- The walkthrough feels like a curated path through the catalog
+
+**Present mode** (`/catalog/walkthrough/:slug?present`):
+
+- Minimal chrome: no catalog header, no sidebar, no breadcrumbs
+- Focused typography: larger base font, generous whitespace, constrained content width for readability on a projector
+- Prev/next navigation remains, styled subtly (bottom of viewport or keyboard-driven)
+- Progress indicator remains (subtle, e.g., bottom bar or "3/8" in corner)
+- Links to catalog resources and forms open in new tabs to preserve presentation flow
+- Keyboard navigation: arrow keys or spacebar advance pages
+
+### Shared Between Modes
+
+- Same markdown rendering pipeline (the catalog already does this)
+- Same prev/next navigation component (styled differently per mode)
+- Same progress indicator component (positioned differently per mode)
+- Same frontmatter parsing
+
+### New Components
+
+- Walkthrough index page (list of sections with metadata)
+- Walkthrough page navigation (prev/next + progress)
+- Present-mode layout wrapper (minimal chrome, focused typography)
+
+Content rendering uses the catalog's existing markdown pipeline. The design system's existing components (badges for rubric tags, cards for the index) cover the UI needs.
+
+## Rubric Coverage Tracking
+
+The walkthrough index page aggregates rubric tags from all walkthrough pages and displays a coverage summary -- which rubric areas are addressed and which have gaps. This provides a dashboard view of presentation readiness at any point during development.
+
+## Integration with Definition of Done
+
+The walkthrough is a living artifact. When a story delivers a capability that the presentation needs to showcase, updating the relevant walkthrough page (or adding a new one) is part of that story's definition of done. The rubric coverage metadata makes gaps visible, preventing last-minute scrambles.
+
+## Persona Targeting
+
+The walkthrough frontmatter includes `audience` tags. The initial implementation shows all pages for all viewers. The metadata supports future filtering (e.g., a shorter "Code for America" version that skips rubric-heavy sections). For now, the full sequence serves all audiences; the presenter adjusts emphasis verbally depending on context.
+
+## Interlinking Pattern
+
+Walkthrough pages use standard markdown links to catalog resources, live forms, and external URLs. A page about extraction links to `../experiments/pdf-field-extraction/_suite.md` and to the live form at `/forms/pardon-application`. In normal mode these navigate inline. In present mode they open in new tabs to preserve flow.
+
+## Key Design Decisions
+
+- **Catalog content type, not standalone route:** The walkthrough lives in the catalog because the evaluator persona already expects the catalog to serve them. This makes the walkthrough discoverable alongside other catalog content and naturally interlinked.
+- **Dual rendering mode:** Same content, two views. Normal mode for browsing and grading; present mode for live presentation. The instructor can switch between them.
+- **Markdown-driven:** Content changes require only markdown edits, no code changes. This keeps the walkthrough maintainable as a living artifact.
+- **Rubric-aware frontmatter:** Makes coverage gaps visible during development and demonstrates systematic project management to the evaluator.

--- a/notes/2026-04-13-walkthrough-presentation/plan.md
+++ b/notes/2026-04-13-walkthrough-presentation/plan.md
@@ -1,0 +1,1379 @@
+# Walkthrough Presentation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a guided walkthrough content type to the catalog with dual rendering modes (normal catalog view and focused presentation mode), populated with initial content covering the project as built to date.
+
+**Architecture:** Walkthrough pages are markdown files in `catalog/walkthrough/` with frontmatter defining order, title, rubric tags, timing, and audience. A new Hono route at `/catalog/walkthrough` renders these as a sequential experience with prev/next navigation. A `?present` query parameter switches to a minimal-chrome presentation layout with keyboard navigation. The index page aggregates rubric coverage from frontmatter metadata.
+
+**Tech Stack:** Hono (server-rendered JSX), markdown-it, USWDS-conformant design system components, CSS cascade layers
+
+---
+
+## File Structure
+
+### New Files
+
+| File | Responsibility |
+|---|---|
+| `src/entrypoints/app/routes/catalog/walkthrough.tsx` | Route handlers: index page and page detail (normal + present modes) |
+| `src/design-system/components/flex-walkthrough-nav/index.tsx` | Prev/next navigation + progress indicator component |
+| `src/design-system/components/flex-walkthrough-nav/styles.css` | Navigation styling for both modes |
+| `src/design-system/components/flex-present-layout/index.tsx` | Minimal-chrome layout for presentation mode |
+| `src/design-system/components/flex-present-layout/styles.css` | Present-mode typography and spacing |
+| `test/catalog-walkthrough.test.ts` | Route integration tests |
+| `catalog/walkthrough/01-the-problem.md` | Walkthrough page: problem space |
+| `catalog/walkthrough/02-our-approach.md` | Walkthrough page: approach and innovation |
+| `catalog/walkthrough/03-llm-assisted-extraction.md` | Walkthrough page: LLM extraction pipeline |
+| `catalog/walkthrough/04-evaluation-and-experimentation.md` | Walkthrough page: evaluation methodology |
+| `catalog/walkthrough/05-production-infrastructure.md` | Walkthrough page: deployment and ops |
+| `catalog/walkthrough/06-inference-pipeline.md` | Walkthrough page: pipeline design |
+| `catalog/walkthrough/07-live-demo.md` | Walkthrough page: interactive demo |
+| `catalog/walkthrough/08-whats-next.md` | Walkthrough page: future work |
+
+### Modified Files
+
+| File | Change |
+|---|---|
+| `src/services/content/types.ts` | Add `WalkthroughPage` interface |
+| `src/entrypoints/app/routes/catalog/index.tsx` | Mount walkthrough route, add card to landing page |
+| `src/entrypoints/app/routes/catalog/sidebar.ts` | Add walkthrough entry to `getCatalogSidebar`, add `getWalkthroughSidebar` |
+| `src/entrypoints/app/public/styles.css` | Import walkthrough-nav and present-layout stylesheets |
+
+---
+
+## Task 1: WalkthroughPage Type and First Content File
+
+**Files:**
+- Modify: `src/services/content/types.ts`
+- Create: `catalog/walkthrough/01-the-problem.md`
+
+- [ ] **Step 1: Add WalkthroughPage type**
+
+In `src/services/content/types.ts`, add after the `Story` interface:
+
+```typescript
+export interface WalkthroughPage {
+  slug: string
+  title: string
+  order: number
+  rubric: string[]
+  timing: string
+  audience: string[]
+  content: string
+}
+```
+
+- [ ] **Step 2: Create first walkthrough content file**
+
+Create `catalog/walkthrough/01-the-problem.md`:
+
+```markdown
+---
+title: "The Problem"
+order: 1
+rubric: []
+timing: "1 min"
+audience: [evaluator, general]
+---
+
+# Government Forms Are Stuck in Paper
+
+Federal agencies manage thousands of forms that collect information from the public. These forms are complex -- multi-page documents with conditional logic, validation rules, sensitivity classifications, and accessibility requirements.
+
+Today, digitizing these forms is a manual, expensive process. A single form can take weeks to convert from PDF to a working web experience. The result is fragile, hard to maintain, and disconnected from the source document.
+
+**What if an LLM could do the heavy lifting?**
+
+Forms Lab explores using large language models to automatically extract structured data from PDF forms and generate accessible, standards-compliant web experiences -- turning weeks of work into minutes.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/services/content/types.ts catalog/walkthrough/01-the-problem.md
+git commit -m "feat(walkthrough): add WalkthroughPage type and first content file"
+```
+
+---
+
+## Task 2: Walkthrough Index Route
+
+**Files:**
+- Create: `src/entrypoints/app/routes/catalog/walkthrough.tsx`
+- Create: `test/catalog-walkthrough.test.ts`
+- Modify: `src/entrypoints/app/routes/catalog/index.tsx`
+
+- [ ] **Step 1: Write failing test for walkthrough index**
+
+Create `test/catalog-walkthrough.test.ts`:
+
+```typescript
+import { describe, expect, it } from 'bun:test'
+import app from '../src/entrypoints/app/server'
+
+describe('Walkthrough Routes', () => {
+  describe('GET /catalog/walkthrough', () => {
+    it('returns 200 and lists walkthrough pages', async () => {
+      const res = await app.request('/catalog/walkthrough')
+      expect(res.status).toBe(200)
+
+      const body = await res.text()
+      expect(body).toContain('Walkthrough')
+      expect(body).toContain('The Problem')
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test test/catalog-walkthrough.test.ts`
+Expected: FAIL (404 — route not registered)
+
+- [ ] **Step 3: Create walkthrough route file**
+
+Create `src/entrypoints/app/routes/catalog/walkthrough.tsx`:
+
+```tsx
+import { join } from 'node:path'
+import { Hono } from 'hono'
+import { ContentCard } from '../../../../design-system/components/flex-card'
+import { CatalogSidebar } from '../../../../design-system/components/flex-catalog-sidebar'
+import { Layout } from '../../../../design-system/components/flex-layout'
+import { TagList } from '../../../../design-system/components/flex-tag-list'
+import { readMarkdownDir } from '../../../../services/content/markdown'
+import type { WalkthroughPage } from '../../../../services/content/types'
+import { resolveUrl } from '../../../../shared/base-path'
+import { getCatalogSidebar } from './sidebar'
+
+const walkthrough = new Hono()
+
+function parseArrayField(value: string | undefined): string[] {
+  if (!value) return []
+  return value
+    .replace(/[[\]]/g, '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+}
+
+function parseWalkthroughPage(file: {
+  frontmatter: Record<string, string>
+  content: string
+  filename: string
+}): WalkthroughPage {
+  return {
+    slug: file.filename,
+    title: file.frontmatter.title || file.filename,
+    order: parseInt(file.frontmatter.order || '0', 10),
+    rubric: parseArrayField(file.frontmatter.rubric),
+    timing: file.frontmatter.timing || '',
+    audience: parseArrayField(file.frontmatter.audience),
+    content: file.content,
+  }
+}
+
+async function loadWalkthroughPages(): Promise<WalkthroughPage[]> {
+  const dir = join(process.cwd(), 'catalog', 'walkthrough')
+  const files = await readMarkdownDir(dir)
+  return files.map(parseWalkthroughPage).sort((a, b) => a.order - b.order)
+}
+
+const RUBRIC_AREAS = [
+  'model-functionality',
+  'innovation',
+  'environment-setup',
+  'inference-pipeline',
+  'technical-documentation',
+  'demo-presentation',
+] as const
+
+walkthrough.get('/', async (c) => {
+  const pages = await loadWalkthroughPages()
+
+  const coveredAreas = new Set(pages.flatMap((p) => p.rubric))
+  const totalMinutes = pages.reduce((sum, p) => {
+    const match = p.timing.match(/(\d+)/)
+    return sum + (match ? parseInt(match[1], 10) : 0)
+  }, 0)
+
+  const sidebarData = getCatalogSidebar('/catalog/walkthrough')
+  const sidebar = <CatalogSidebar sections={sidebarData} />
+
+  const firstPage = pages[0]
+
+  return c.html(
+    <Layout
+      title="Walkthrough"
+      sidebar={sidebar}
+      currentPath="/catalog"
+      user={c.get('user')}
+    >
+      <h1>Project Walkthrough</h1>
+      <p>
+        A guided tour of the Forms Lab project — problem, approach, LLM
+        integration, production environment, and live demo.
+        {totalMinutes > 0 && <> Estimated time: {totalMinutes} minutes.</>}
+      </p>
+
+      {firstPage && (
+        <p>
+          <a href={resolveUrl(`/catalog/walkthrough/${firstPage.slug}`)} class="flex-button">
+            Start walkthrough
+          </a>
+        </p>
+      )}
+
+      <section>
+        <h2>Rubric Coverage</h2>
+        <div class="l-cluster">
+          {RUBRIC_AREAS.map((area) => (
+            <span
+              key={area}
+              class="badge"
+              data-status={coveredAreas.has(area) ? 'closed' : 'open'}
+            >
+              {area}
+            </span>
+          ))}
+        </div>
+      </section>
+
+      <section>
+        <h2>Sections</h2>
+        <div class="l-stack">
+          {pages.map((page, i) => (
+            <ContentCard
+              key={page.slug}
+              title={`${i + 1}. ${page.title}`}
+              href={resolveUrl(`/catalog/walkthrough/${page.slug}`)}
+              description={page.timing ? `${page.timing}` : undefined}
+            >
+              <TagList tags={page.rubric} />
+            </ContentCard>
+          ))}
+        </div>
+      </section>
+    </Layout>,
+  )
+})
+
+export default walkthrough
+```
+
+- [ ] **Step 4: Register the route in catalog index**
+
+In `src/entrypoints/app/routes/catalog/index.tsx`, add the import and route:
+
+Add import:
+```typescript
+import walkthrough from './walkthrough'
+```
+
+Add route (after the existing `catalog.route` calls):
+```typescript
+catalog.route('/walkthrough', walkthrough)
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `bun test test/catalog-walkthrough.test.ts`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/entrypoints/app/routes/catalog/walkthrough.tsx src/entrypoints/app/routes/catalog/index.tsx test/catalog-walkthrough.test.ts
+git commit -m "feat(walkthrough): add index route with rubric coverage summary"
+```
+
+---
+
+## Task 3: Walkthrough Page Route with Navigation (Normal Mode)
+
+**Files:**
+- Create: `src/design-system/components/flex-walkthrough-nav/index.tsx`
+- Create: `src/design-system/components/flex-walkthrough-nav/styles.css`
+- Modify: `src/entrypoints/app/routes/catalog/walkthrough.tsx`
+- Modify: `src/entrypoints/app/public/styles.css`
+- Modify: `test/catalog-walkthrough.test.ts`
+
+- [ ] **Step 1: Write failing test for page detail route**
+
+Add to `test/catalog-walkthrough.test.ts`:
+
+```typescript
+describe('GET /catalog/walkthrough/:slug', () => {
+  it('returns 200 and renders walkthrough page', async () => {
+    const res = await app.request('/catalog/walkthrough/01-the-problem')
+    expect(res.status).toBe(200)
+
+    const body = await res.text()
+    expect(body).toContain('The Problem')
+    expect(body).toContain('Government Forms')
+  })
+
+  it('shows progress indicator', async () => {
+    const res = await app.request('/catalog/walkthrough/01-the-problem')
+    const body = await res.text()
+    expect(body).toContain('1 of')
+  })
+
+  it('returns 404 for unknown slug', async () => {
+    const res = await app.request('/catalog/walkthrough/nonexistent')
+    expect(res.status).toBe(404)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test test/catalog-walkthrough.test.ts`
+Expected: FAIL (route not found, 404 for valid slug)
+
+- [ ] **Step 3: Create WalkthroughNav component**
+
+Create `src/design-system/components/flex-walkthrough-nav/index.tsx`:
+
+```tsx
+import type { FC } from 'hono/jsx'
+
+interface WalkthroughNavProps {
+  currentPage: number
+  totalPages: number
+  prevUrl: string | null
+  nextUrl: string | null
+}
+
+export const WalkthroughNav: FC<WalkthroughNavProps> = ({
+  currentPage,
+  totalPages,
+  prevUrl,
+  nextUrl,
+}) => {
+  return (
+    <nav class="flex-walkthrough-nav" aria-label="Walkthrough navigation">
+      <span class="flex-walkthrough-nav__progress">
+        {currentPage} of {totalPages}
+      </span>
+      <div class="flex-walkthrough-nav__controls">
+        {prevUrl ? (
+          <a href={prevUrl} class="flex-walkthrough-nav__link">
+            ← Previous
+          </a>
+        ) : (
+          <span class="flex-walkthrough-nav__link" data-disabled>
+            ← Previous
+          </span>
+        )}
+        {nextUrl ? (
+          <a href={nextUrl} class="flex-walkthrough-nav__link">
+            Next →
+          </a>
+        ) : (
+          <span class="flex-walkthrough-nav__link" data-disabled>
+            Next →
+          </span>
+        )}
+      </div>
+    </nav>
+  )
+}
+```
+
+- [ ] **Step 4: Create WalkthroughNav styles**
+
+Create `src/design-system/components/flex-walkthrough-nav/styles.css`:
+
+```css
+.flex-walkthrough-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-block: var(--flex-space-md);
+  border-block-start: 1px solid var(--flex-color-border);
+  margin-block-start: var(--flex-space-lg);
+}
+
+.flex-walkthrough-nav__progress {
+  font-size: var(--flex-text-sm);
+  color: var(--flex-color-text-muted);
+}
+
+.flex-walkthrough-nav__controls {
+  display: flex;
+  gap: var(--flex-space-md);
+}
+
+.flex-walkthrough-nav__link {
+  color: var(--flex-color-accent);
+  text-decoration: none;
+  font-weight: 700;
+}
+
+.flex-walkthrough-nav__link:hover {
+  text-decoration: underline;
+}
+
+.flex-walkthrough-nav__link[data-disabled] {
+  color: var(--flex-color-text-muted);
+  pointer-events: none;
+}
+```
+
+- [ ] **Step 5: Add stylesheet import**
+
+In `src/entrypoints/app/public/styles.css`, add before the `/* Utility */` comment:
+
+```css
+@import "../../../design-system/components/flex-walkthrough-nav/styles.css" layer(block);
+```
+
+- [ ] **Step 6: Add page detail route handler**
+
+In `src/entrypoints/app/routes/catalog/walkthrough.tsx`, add these new imports at the top, and update the existing markdown import to also include `renderMarkdown`:
+
+```typescript
+import { Breadcrumb } from '../../../../design-system/components/flex-breadcrumb'
+import { Prose } from '../../../../design-system/components/flex-prose'
+import { WalkthroughNav } from '../../../../design-system/components/flex-walkthrough-nav'
+```
+
+Update the existing import:
+```typescript
+import { readMarkdownDir, renderMarkdown } from '../../../../services/content/markdown'
+```
+
+Then add the route handler after the `walkthrough.get('/')` handler and before `export default walkthrough`:
+
+```tsx
+walkthrough.get('/:slug', async (c) => {
+  const slug = c.req.param('slug')
+  const pages = await loadWalkthroughPages()
+  const pageIndex = pages.findIndex((p) => p.slug === slug)
+
+  if (pageIndex === -1) {
+    const sidebarData = getCatalogSidebar('/catalog/walkthrough')
+    const sidebar = <CatalogSidebar sections={sidebarData} />
+    return c.html(
+      <Layout
+        title="Not Found"
+        sidebar={sidebar}
+        currentPath="/catalog"
+        user={c.get('user')}
+      >
+        <h1>Page Not Found</h1>
+        <p>The walkthrough page "{slug}" does not exist.</p>
+      </Layout>,
+      404,
+    )
+  }
+
+  const page = pages[pageIndex]
+  const prevPage = pageIndex > 0 ? pages[pageIndex - 1] : null
+  const nextPage = pageIndex < pages.length - 1 ? pages[pageIndex + 1] : null
+
+  const sidebarData = getCatalogSidebar('/catalog/walkthrough')
+  const sidebar = <CatalogSidebar sections={sidebarData} />
+
+  return c.html(
+    <Layout
+      title={page.title}
+      sidebar={sidebar}
+      currentPath="/catalog"
+      user={c.get('user')}
+    >
+      <Breadcrumb
+        items={[
+          { label: 'Catalog', href: resolveUrl('/catalog') },
+          { label: 'Walkthrough', href: resolveUrl('/catalog/walkthrough') },
+          { label: page.title },
+        ]}
+      />
+      <Prose html={renderMarkdown(page.content)} />
+      <WalkthroughNav
+        currentPage={pageIndex + 1}
+        totalPages={pages.length}
+        prevUrl={
+          prevPage
+            ? resolveUrl(`/catalog/walkthrough/${prevPage.slug}`)
+            : null
+        }
+        nextUrl={
+          nextPage
+            ? resolveUrl(`/catalog/walkthrough/${nextPage.slug}`)
+            : null
+        }
+      />
+    </Layout>,
+  )
+})
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `bun test test/catalog-walkthrough.test.ts`
+Expected: All PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/design-system/components/flex-walkthrough-nav/ src/entrypoints/app/routes/catalog/walkthrough.tsx src/entrypoints/app/public/styles.css test/catalog-walkthrough.test.ts
+git commit -m "feat(walkthrough): add page detail route with prev/next navigation"
+```
+
+---
+
+## Task 4: Sidebar Integration and Catalog Landing Card
+
+**Files:**
+- Modify: `src/entrypoints/app/routes/catalog/sidebar.ts`
+- Modify: `src/entrypoints/app/routes/catalog/index.tsx`
+- Modify: `src/entrypoints/app/routes/catalog/walkthrough.tsx`
+- Modify: `test/catalog-walkthrough.test.ts`
+
+- [ ] **Step 1: Write failing test for sidebar**
+
+Add to `test/catalog-walkthrough.test.ts`:
+
+```typescript
+it('shows walkthrough link in catalog sidebar', async () => {
+  const res = await app.request('/catalog')
+  const body = await res.text()
+  expect(body).toContain('Walkthrough')
+  expect(body).toContain('/catalog/walkthrough')
+})
+
+it('shows contextual sidebar on walkthrough pages', async () => {
+  const res = await app.request('/catalog/walkthrough/01-the-problem')
+  const body = await res.text()
+  expect(body).toContain('← Back to Catalog')
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test test/catalog-walkthrough.test.ts`
+Expected: FAIL (sidebar doesn't include walkthrough entries)
+
+- [ ] **Step 3: Add walkthrough to getCatalogSidebar**
+
+In `src/entrypoints/app/routes/catalog/sidebar.ts`, add a new section to the `getCatalogSidebar` function. Add this object to the returned array, after the "The System" section and before "The Work" section:
+
+```typescript
+{
+  title: 'Presentation',
+  items: [
+    {
+      label: 'Walkthrough',
+      href: resolveUrl('/catalog/walkthrough'),
+      current: currentPath === '/catalog/walkthrough',
+    },
+  ],
+},
+```
+
+- [ ] **Step 4: Add getWalkthroughSidebar function**
+
+In `src/entrypoints/app/routes/catalog/sidebar.ts`, add the import for WalkthroughPage and the new sidebar function:
+
+```typescript
+import type { Decision, Story, WalkthroughPage } from '../../../../services/content/types'
+```
+
+```typescript
+export function getWalkthroughSidebar(
+  pages: WalkthroughPage[],
+  currentPath?: string,
+) {
+  return [
+    {
+      title: 'Walkthrough',
+      items: [
+        {
+          label: '← Back to Catalog',
+          href: resolveUrl('/catalog'),
+          current: false,
+        },
+        {
+          label: 'Overview',
+          href: resolveUrl('/catalog/walkthrough'),
+          current: currentPath === '/catalog/walkthrough',
+        },
+        ...pages.map((p, i) => ({
+          label: `${i + 1}. ${p.title}`,
+          href: resolveUrl(`/catalog/walkthrough/${p.slug}`),
+          current: currentPath === `/catalog/walkthrough/${p.slug}`,
+        })),
+      ],
+    },
+  ]
+}
+```
+
+- [ ] **Step 5: Use contextual sidebar in walkthrough routes**
+
+In `src/entrypoints/app/routes/catalog/walkthrough.tsx`, add the import:
+
+```typescript
+import { getCatalogSidebar, getWalkthroughSidebar } from './sidebar'
+```
+
+(Replace the existing `import { getCatalogSidebar } from './sidebar'`)
+
+Update the index handler to use the walkthrough sidebar:
+
+Replace `const sidebarData = getCatalogSidebar('/catalog/walkthrough')` with:
+```typescript
+const sidebarData = getWalkthroughSidebar(pages, '/catalog/walkthrough')
+```
+
+Update the page detail handler similarly. Replace `const sidebarData = getCatalogSidebar('/catalog/walkthrough')` with:
+```typescript
+const sidebarData = getWalkthroughSidebar(pages, `/catalog/walkthrough/${slug}`)
+```
+
+Also update the 404 handler in the page detail route to use the walkthrough sidebar (load pages before the 404 check — they're already loaded).
+
+- [ ] **Step 6: Add walkthrough card to catalog landing page**
+
+In `src/entrypoints/app/routes/catalog/index.tsx`, add a new section in the landing page JSX. Add this before the "The System" section:
+
+```tsx
+<section>
+  <p class="catalog-group-label">Presentation</p>
+  <div class="l-grid" style="--grid-min: 280px">
+    <ContentCard
+      title="Walkthrough"
+      href={resolveUrl('/catalog/walkthrough')}
+      description="Guided tour of the project — problem, approach, LLM integration, and demo"
+    />
+  </div>
+</section>
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `bun test test/catalog-walkthrough.test.ts`
+Expected: All PASS
+
+- [ ] **Step 8: Run full test suite**
+
+Run: `bun test`
+Expected: All PASS (no regressions)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/entrypoints/app/routes/catalog/sidebar.ts src/entrypoints/app/routes/catalog/index.tsx src/entrypoints/app/routes/catalog/walkthrough.tsx test/catalog-walkthrough.test.ts
+git commit -m "feat(walkthrough): add sidebar integration and catalog landing card"
+```
+
+---
+
+## Task 5: Present Mode
+
+**Files:**
+- Create: `src/design-system/components/flex-present-layout/index.tsx`
+- Create: `src/design-system/components/flex-present-layout/styles.css`
+- Modify: `src/entrypoints/app/routes/catalog/walkthrough.tsx`
+- Modify: `src/entrypoints/app/public/styles.css`
+- Modify: `test/catalog-walkthrough.test.ts`
+
+- [ ] **Step 1: Write failing tests for present mode**
+
+Add to `test/catalog-walkthrough.test.ts`:
+
+```typescript
+describe('Present mode', () => {
+  it('returns 200 for walkthrough page in present mode', async () => {
+    const res = await app.request(
+      '/catalog/walkthrough/01-the-problem?present',
+    )
+    expect(res.status).toBe(200)
+  })
+
+  it('does not render catalog header in present mode', async () => {
+    const res = await app.request(
+      '/catalog/walkthrough/01-the-problem?present',
+    )
+    const body = await res.text()
+    expect(body).not.toContain('flex-header')
+    expect(body).toContain('flex-present-layout')
+    expect(body).toContain('The Problem')
+  })
+
+  it('includes keyboard navigation script in present mode', async () => {
+    const res = await app.request(
+      '/catalog/walkthrough/01-the-problem?present',
+    )
+    const body = await res.text()
+    expect(body).toContain('ArrowRight')
+  })
+
+  it('renders index as title slide in present mode', async () => {
+    const res = await app.request('/catalog/walkthrough?present')
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    expect(body).toContain('flex-present-layout')
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test test/catalog-walkthrough.test.ts`
+Expected: FAIL (present mode not implemented)
+
+- [ ] **Step 3: Create PresentLayout component**
+
+Create `src/design-system/components/flex-present-layout/index.tsx`:
+
+```tsx
+import type { Child, FC, PropsWithChildren } from 'hono/jsx'
+import { resolveUrl } from '../../../shared/base-path'
+
+interface PresentLayoutProps {
+  title?: string
+  nav?: Child
+}
+
+export const PresentLayout: FC<PropsWithChildren<PresentLayoutProps>> = (
+  props,
+) => {
+  const title = props.title ? `${props.title} | Forms Lab` : 'Forms Lab'
+
+  return (
+    <html lang="en" data-theme="auto">
+      <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>{title}</title>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){var t=localStorage.getItem('theme');if(t==='light'||t==='dark'||t==='auto')document.documentElement.setAttribute('data-theme',t)})()`,
+          }}
+        />
+        <link rel="stylesheet" href={resolveUrl('/static/styles.css')} />
+      </head>
+      <body>
+        <main class="flex-present-layout">
+          <div class="flex-present-layout__content">{props.children}</div>
+          {props.nav && (
+            <div class="flex-present-layout__nav">{props.nav}</div>
+          )}
+        </main>
+        <script
+          type="module"
+          src={resolveUrl('/static/components.js')}
+        />
+      </body>
+    </html>
+  )
+}
+```
+
+- [ ] **Step 4: Create PresentLayout styles**
+
+Create `src/design-system/components/flex-present-layout/styles.css`:
+
+```css
+.flex-present-layout {
+  display: flex;
+  flex-direction: column;
+  min-block-size: 100vh;
+  min-block-size: 100dvh;
+  padding: var(--flex-space-xl) var(--flex-space-lg);
+}
+
+.flex-present-layout__content {
+  flex: 1;
+  max-inline-size: 50rem;
+  margin-inline: auto;
+  inline-size: 100%;
+}
+
+.flex-present-layout__content .prose {
+  font-size: var(--flex-text-lg);
+  line-height: 1.6;
+}
+
+.flex-present-layout__content .prose h1 {
+  font-size: var(--flex-text-3xl);
+  margin-block-end: var(--flex-space-lg);
+}
+
+.flex-present-layout__content .prose h2 {
+  font-size: var(--flex-text-2xl);
+  margin-block-start: var(--flex-space-xl);
+}
+
+.flex-present-layout__content .prose a {
+  text-decoration: underline;
+}
+
+.flex-present-layout__nav {
+  max-inline-size: 50rem;
+  margin-inline: auto;
+  inline-size: 100%;
+}
+
+.flex-present-layout .flex-walkthrough-nav {
+  border-block-start: none;
+  margin-block-start: 0;
+}
+```
+
+- [ ] **Step 5: Add stylesheet imports**
+
+In `src/entrypoints/app/public/styles.css`, add before the `/* Utility */` comment:
+
+```css
+@import "../../../design-system/components/flex-present-layout/styles.css" layer(block);
+```
+
+- [ ] **Step 6: Add present mode to walkthrough routes**
+
+In `src/entrypoints/app/routes/catalog/walkthrough.tsx`, add the PresentLayout import:
+
+```typescript
+import { PresentLayout } from '../../../../design-system/components/flex-present-layout'
+```
+
+Update the page detail handler. Replace the existing `walkthrough.get('/:slug', ...)` handler with a version that checks for `?present`:
+
+After computing `page`, `prevPage`, `nextPage`, and before the sidebar logic, add:
+
+```tsx
+const isPresent = c.req.query('present') !== undefined
+
+if (isPresent) {
+  const prevUrl = prevPage
+    ? resolveUrl(`/catalog/walkthrough/${prevPage.slug}?present`)
+    : null
+  const nextUrl = nextPage
+    ? resolveUrl(`/catalog/walkthrough/${nextPage.slug}?present`)
+    : null
+
+  return c.html(
+    <PresentLayout
+      title={page.title}
+      nav={
+        <WalkthroughNav
+          currentPage={pageIndex + 1}
+          totalPages={pages.length}
+          prevUrl={prevUrl}
+          nextUrl={nextUrl}
+        />
+      }
+    >
+      <Prose html={renderMarkdown(page.content)} />
+      <script
+        dangerouslySetInnerHTML={{
+          __html: `(function(){
+            var prev=${prevUrl ? `"${prevUrl}"` : 'null'};
+            var next=${nextUrl ? `"${nextUrl}"` : 'null'};
+            document.addEventListener('keydown',function(e){
+              if(e.key==='ArrowRight'||e.key===' '){if(next){e.preventDefault();location.href=next}}
+              if(e.key==='ArrowLeft'){if(prev){e.preventDefault();location.href=prev}}
+              if(e.key==='Escape'){location.href='${resolveUrl('/catalog/walkthrough')}'}
+            });
+            document.querySelectorAll('.prose a').forEach(function(a){
+              if(!a.getAttribute('href').startsWith('#'))a.setAttribute('target','_blank')
+            });
+          }())`,
+        }}
+      />
+    </PresentLayout>,
+  )
+}
+```
+
+Also update the index handler to support present mode. After computing `pages`, `coveredAreas`, `totalMinutes`, and `firstPage`, add:
+
+```tsx
+const isPresent = c.req.query('present') !== undefined
+
+if (isPresent) {
+  const firstUrl = firstPage
+    ? resolveUrl(`/catalog/walkthrough/${firstPage.slug}?present`)
+    : null
+
+  return c.html(
+    <PresentLayout title="Walkthrough">
+      <div style="display:flex;flex-direction:column;align-items:center;justify-content:center;min-height:60vh;text-align:center">
+        <h1 style="font-size:var(--flex-text-3xl);margin-block-end:var(--flex-space-md)">
+          Forms Lab
+        </h1>
+        <p style="font-size:var(--flex-text-xl);color:var(--flex-color-text-muted);margin-block-end:var(--flex-space-xl)">
+          LLM-Assisted Forms Platform for Government
+        </p>
+        {firstUrl && (
+          <a href={firstUrl} class="flex-button" data-size="big">
+            Begin →
+          </a>
+        )}
+        <p style="font-size:var(--flex-text-sm);color:var(--flex-color-text-muted);margin-block-start:var(--flex-space-lg)">
+          Press → or click to begin
+        </p>
+      </div>
+      {firstUrl && (
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `document.addEventListener('keydown',function(e){if(e.key==='ArrowRight'||e.key===' '){e.preventDefault();location.href='${firstUrl}'}})`,
+          }}
+        />
+      )}
+    </PresentLayout>,
+  )
+}
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `bun test test/catalog-walkthrough.test.ts`
+Expected: All PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/design-system/components/flex-present-layout/ src/entrypoints/app/routes/catalog/walkthrough.tsx src/entrypoints/app/public/styles.css test/catalog-walkthrough.test.ts
+git commit -m "feat(walkthrough): add presentation mode with keyboard navigation"
+```
+
+---
+
+## Task 6: Remaining Walkthrough Content
+
+**Files:**
+- Create: `catalog/walkthrough/02-our-approach.md`
+- Create: `catalog/walkthrough/03-llm-assisted-extraction.md`
+- Create: `catalog/walkthrough/04-evaluation-and-experimentation.md`
+- Create: `catalog/walkthrough/05-production-infrastructure.md`
+- Create: `catalog/walkthrough/06-inference-pipeline.md`
+- Create: `catalog/walkthrough/07-live-demo.md`
+- Create: `catalog/walkthrough/08-whats-next.md`
+- Modify: `test/catalog-walkthrough.test.ts`
+
+- [ ] **Step 1: Write failing test for all pages**
+
+Add to `test/catalog-walkthrough.test.ts`:
+
+```typescript
+describe('All walkthrough pages render', () => {
+  const slugs = [
+    '01-the-problem',
+    '02-our-approach',
+    '03-llm-assisted-extraction',
+    '04-evaluation-and-experimentation',
+    '05-production-infrastructure',
+    '06-inference-pipeline',
+    '07-live-demo',
+    '08-whats-next',
+  ]
+
+  for (const slug of slugs) {
+    it(`renders ${slug}`, async () => {
+      const res = await app.request(`/catalog/walkthrough/${slug}`)
+      expect(res.status).toBe(200)
+    })
+  }
+
+  it('shows correct total page count in navigation', async () => {
+    const res = await app.request('/catalog/walkthrough/01-the-problem')
+    const body = await res.text()
+    expect(body).toContain('1 of 8')
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test test/catalog-walkthrough.test.ts`
+Expected: FAIL (only page 01 exists, others 404)
+
+- [ ] **Step 3: Create walkthrough page 02**
+
+Create `catalog/walkthrough/02-our-approach.md`:
+
+```markdown
+---
+title: "Our Approach"
+order: 2
+rubric: [innovation]
+timing: "2 min"
+audience: [evaluator, general]
+---
+
+# An LLM-Native Forms Platform
+
+Rather than bolting LLM features onto an existing forms product, Forms Lab was designed from the ground up around LLM capabilities.
+
+## The Core Insight
+
+Government forms are structured documents. They encode a **data collection specification** — what information to gather, in what format, under what conditions. An LLM can extract this structure directly from a PDF.
+
+## Architecture
+
+The system separates three concerns:
+
+- **DataCollectionSpec** — What to collect: fields, types, constraints, conditions, sensitivity classifications
+- **FormSpec** — How to present it: pages, sections, delivery modes, visual layout
+- **Submission** — Collected data, linked to the exact spec version
+
+This separation means the LLM extraction produces a DataCollectionSpec, and the system can generate multiple presentation formats from the same underlying data model.
+
+## What Makes This Different
+
+- **Not just chat**: The LLM does structured extraction, not conversational interaction
+- **Systematic evaluation**: Every extraction is scored against ground truth with quantitative metrics
+- **Production-grade**: Full deployment pipeline, not a notebook demo
+- **Standards-compliant**: Output meets USWDS accessibility and design standards
+
+See: [Architecture](/catalog/architecture) | [Data Model](/catalog/architecture/data-model) | [Design Decisions](/catalog/decisions)
+```
+
+- [ ] **Step 4: Create walkthrough page 03**
+
+Create `catalog/walkthrough/03-llm-assisted-extraction.md`:
+
+```markdown
+---
+title: "LLM-Assisted Extraction"
+order: 3
+rubric: [model-functionality, innovation]
+timing: "3 min"
+audience: [evaluator, general]
+---
+
+# From PDF to Structured Data
+
+The core LLM integration: given a government PDF form, extract a complete DataCollectionSpec — fields, types, grouping, conditions, and sensitivity classifications.
+
+## How It Works
+
+1. **Upload**: Maya (form creator persona) uploads a PDF form
+2. **Extract**: The system sends the PDF to Claude via Amazon Bedrock
+3. **Structure**: Claude returns a structured DataCollectionSpec with fields, types, groups, conditions
+4. **Review**: Maya reviews the extracted spec in the catalog browser
+
+## The Prompt
+
+The extraction prompt asks Claude to identify:
+
+- **Fields**: Name, label, type (text, number, date, boolean, select), help text
+- **Groups**: Logical grouping of related fields (e.g., "Personal Information")
+- **Conditions**: When a field should appear based on other field values
+- **Sensitivity**: PII classification (name, SSN, address, etc.)
+
+## Strategy Pattern
+
+The extractor uses a strategy pattern (`PdfExtractor` interface) so implementations can be swapped for experimentation:
+
+- `ApiPdfExtractor` — Current implementation using Claude via Bedrock
+- Future: alternative models, different prompting strategies, chunking approaches
+
+## Test Form
+
+The primary evaluation form is a 24-page DOJ Pardon Application — a complex, real-world government form with conditional logic, multiple sections, and various field types.
+
+See: [Experiments](/catalog/experiments) | [Story #3](/catalog/stories/3-maya-uploads-a-pdf-and-reviews-the-extracted-specs)
+```
+
+- [ ] **Step 5: Create walkthrough page 04**
+
+Create `catalog/walkthrough/04-evaluation-and-experimentation.md`:
+
+```markdown
+---
+title: "Evaluation & Experimentation"
+order: 4
+rubric: [model-functionality]
+timing: "3 min"
+audience: [evaluator]
+---
+
+# Systematic Model Evaluation
+
+Evaluation is not an afterthought — it is built into the development workflow.
+
+## Evaluation Framework
+
+Every extraction is scored against a manually-created ground truth using quantitative metrics:
+
+| Metric | What It Measures |
+|---|---|
+| Field Recall | Did we find all the fields? |
+| Field Precision | Did we only find real fields (no hallucinations)? |
+| Type Accuracy | Did we assign correct types (text, number, date, etc.)? |
+| Group Accuracy | Did we group related fields correctly? |
+| Sensitivity Accuracy | Did we classify PII correctly? |
+
+## Model Comparison
+
+The evaluation harness runs the same test suite across different models:
+
+| Model | Field Recall | Field Precision | Type Accuracy |
+|---|---|---|---|
+| Opus (baseline) | 100% | 100% | 100% |
+| Sonnet | Evaluated | Evaluated | Evaluated |
+| Haiku | Evaluated | Evaluated | Evaluated |
+
+## Scoring Methods
+
+Two complementary approaches:
+
+1. **Deterministic scoring** — Exact fieldName + normalized label match. Fast, reproducible, but undercounts synonyms and naming variations.
+2. **LLM-as-Judge** — Uses a separate LLM call to semantically match extracted fields against ground truth. Handles synonyms, prefixes, and structural variations.
+
+The LLM-as-Judge approach itself is a significant LLM integration point — using one model to evaluate another model's output.
+
+See: [Experiment Suite](/catalog/experiments/pdf-field-extraction) | [Evaluation Decisions](/catalog/decisions)
+```
+
+- [ ] **Step 6: Create walkthrough page 05**
+
+Create `catalog/walkthrough/05-production-infrastructure.md`:
+
+```markdown
+---
+title: "Production Infrastructure"
+order: 5
+rubric: [environment-setup]
+timing: "2 min"
+audience: [evaluator]
+---
+
+# Deployment Architecture
+
+Forms Lab runs in a production environment on AWS, provisioned and managed through infrastructure-as-code.
+
+## Stack
+
+- **Compute**: EC2 instance provisioned via Pulumi (TypeScript)
+- **OS**: NixOS — declarative, reproducible system configuration
+- **Reverse proxy**: Caddy with automatic TLS
+- **Runtime**: Bun (JavaScript/TypeScript runtime)
+- **LLM API**: Claude via Amazon Bedrock (cross-account SSO)
+
+## Branch-Per-Deployment Model
+
+Every git branch gets its own deployment:
+
+- Push to any branch → GitHub webhook triggers deployment
+- Each branch runs as a separate process on an assigned port
+- Caddy routes `/<branch>/*` to the correct process
+- Push to `main` also restarts the homepage dashboard
+
+This means reviewers can visit any branch's deployment directly by URL.
+
+## Infrastructure as Code
+
+- **Pulumi**: Provisions EC2, security groups, IAM roles
+- **NixOS flake**: Defines system packages, services, Caddy config, deploy scripts
+- **GitHub webhook**: Receives push events, triggers `deploy.sh`
+
+See: [Deployment Architecture](/catalog/architecture/deployment) | [Infrastructure Decisions](/catalog/decisions/infrastructure)
+```
+
+- [ ] **Step 7: Create walkthrough page 06**
+
+Create `catalog/walkthrough/06-inference-pipeline.md`:
+
+```markdown
+---
+title: "Inference Pipeline"
+order: 6
+rubric: [inference-pipeline]
+timing: "2 min"
+audience: [evaluator]
+---
+
+# Inference Pipeline Design
+
+The inference pipeline handles communication between the Forms Lab application and Claude via Amazon Bedrock.
+
+## Pipeline Architecture
+
+```
+PDF Upload → PdfExtractor (strategy) → Bedrock API → Parse Response → DataCollectionSpec
+```
+
+The pipeline follows a strategy pattern:
+
+- **Interface**: `PdfExtractor` defines the extraction contract
+- **Implementation**: `ApiPdfExtractor` calls Claude via Bedrock
+- **Configuration**: Model ID, sampling parameters, and system prompt are configurable
+
+## Bedrock Integration
+
+- **Service**: Amazon Bedrock (managed LLM inference)
+- **Authentication**: Cross-account SSO via AWS IAM roles
+- **Models available**: Claude Opus, Sonnet, Haiku — all accessible through the same endpoint
+- **Region**: us-east-1
+
+## Sampling and Parameters
+
+The extraction prompt uses structured output to ensure reliable JSON parsing:
+
+- **Temperature**: Low (precise extraction, not creative generation)
+- **Max tokens**: Scaled to form complexity
+- **System prompt**: Defines the extraction schema and domain rules
+
+## Error Handling
+
+- Bedrock API errors are caught and surfaced to the user
+- Malformed extraction results are validated against the DataCollectionSpec schema
+- Extraction confidence is tracked per-field for review
+
+See: [Story #3](/catalog/stories/3-maya-uploads-a-pdf-and-reviews-the-extracted-specs) | [Extraction Experiments](/catalog/experiments/pdf-field-extraction)
+```
+
+- [ ] **Step 8: Create walkthrough page 07**
+
+Create `catalog/walkthrough/07-live-demo.md`:
+
+```markdown
+---
+title: "Live Demo"
+order: 7
+rubric: [demo-presentation]
+timing: "2 min"
+audience: [evaluator, general]
+---
+
+# See It In Action
+
+Forms Lab is a working application. Here are the key paths to explore:
+
+## Upload and Extract
+
+1. [Sign in](/auth/signin) with GitHub
+2. Navigate to [Projects](/projects)
+3. Upload a PDF form
+4. Watch the LLM extract a structured DataCollectionSpec
+5. Review the extracted fields, types, groups, and conditions
+
+## Fill a Form
+
+1. Visit the [Forms](/forms) index
+2. Select an available form
+3. Walk through the multi-page form experience
+4. See conditional fields appear based on your answers
+5. Review your submission on the summary page
+
+## Explore the Catalog
+
+The [Catalog](/catalog) is the project's self-documenting system:
+
+- [Personas](/catalog/personas) — Who the system serves
+- [Architecture](/catalog/architecture) — How it's built
+- [Decisions](/catalog/decisions) — Why we made each choice
+- [Experiments](/catalog/experiments) — What we tested and learned
+- [Design System](/catalog/design-system) — Visual language and components
+
+## Deployment Dashboard
+
+The [Homepage](/) shows all active deployments with health status, branch names, and commit hashes.
+```
+
+- [ ] **Step 9: Create walkthrough page 08**
+
+Create `catalog/walkthrough/08-whats-next.md`:
+
+```markdown
+---
+title: "What's Next"
+order: 8
+rubric: []
+timing: "1 min"
+audience: [evaluator, general]
+---
+
+# What's Next
+
+Forms Lab demonstrates the foundation. Here's where it goes from here:
+
+## Planned Capabilities
+
+- **Conversational form filling** — Carlos completes complex sections through dialogue with an LLM agent (Story #9)
+- **LLM-assisted refinement** — Maya uses conversation to iteratively improve the data model (Story #8)
+- **Advanced evaluation** — LLM-as-Judge scoring for richer, semantic evaluation of extraction quality
+- **Form shaping** — Maya customizes delivery modes, page flow, and visual presentation (Story #4)
+- **PDF generation** — Complete the round-trip: PDF in, web form, PDF out with filled data (Story #7)
+
+## Open Questions
+
+- How well does extraction generalize across form types (tax forms, benefit applications, regulatory filings)?
+- What's the right balance between automatic extraction and human refinement?
+- Can the evaluation framework itself be used to improve extraction prompts automatically?
+
+## The Bigger Picture
+
+Government forms represent one of the highest-volume, highest-impact touchpoints between agencies and the public. Making these forms easier to create, more accessible to fill out, and more reliable to process is a meaningful application of LLM technology.
+
+See: [All Stories](/catalog/stories) | [Architecture](/catalog/architecture/system-overview)
+```
+
+- [ ] **Step 10: Run tests to verify they pass**
+
+Run: `bun test test/catalog-walkthrough.test.ts`
+Expected: All PASS
+
+- [ ] **Step 11: Run full test suite**
+
+Run: `bun test`
+Expected: All PASS
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add catalog/walkthrough/ test/catalog-walkthrough.test.ts
+git commit -m "feat(walkthrough): add initial walkthrough content covering project to date"
+```
+
+---
+
+## Task 7: Final Verification and Cleanup
+
+**Files:**
+- Possibly modify: any files with issues found during verification
+
+- [ ] **Step 1: Run full checks**
+
+Run: `bun run check`
+Expected: Lint, type check, and all tests pass
+
+- [ ] **Step 2: Start dev server and verify in browser**
+
+Run: `bun run dev`
+
+Verify manually:
+1. Visit `/catalog` — walkthrough card appears in landing page
+2. Visit `/catalog/walkthrough` — index shows all 8 sections, rubric coverage, total timing
+3. Click "Start walkthrough" — navigates to page 1
+4. Click through all pages using prev/next navigation
+5. Verify progress indicator updates ("1 of 8", "2 of 8", etc.)
+6. Verify sidebar shows all walkthrough pages with current page highlighted
+7. Visit `/catalog/walkthrough?present` — title slide with "Begin →" button
+8. Click through all pages in present mode — no header, footer, or sidebar
+9. Test keyboard navigation: → advances, ← goes back, Escape exits to index
+10. Verify links in present mode open in new tabs
+11. Verify breadcrumbs work in normal mode
+
+- [ ] **Step 3: Fix any issues found**
+
+Address any visual, functional, or accessibility issues discovered during browser testing.
+
+- [ ] **Step 4: Final commit if needed**
+
+```bash
+git add -A
+git commit -m "fix(walkthrough): address issues from browser verification"
+```
+
+- [ ] **Step 5: Run checks one final time**
+
+Run: `bun run check`
+Expected: All pass

--- a/notes/final-project-rubric.md
+++ b/notes/final-project-rubric.md
@@ -1,0 +1,49 @@
+# Final Project Rubric (100 Points)
+
+## I. Model & Inference (40 Points)
+
+### Model Functionality (20 Points)
+
+- **Excellent (16-20):** Model successfully trained and running, producing meaningful outputs for the chosen task. Includes a LoRA if trained. Crucially, demonstrates a thoughtful evaluation process -- creation and use of an evaluation dataset to assess model performance is encouraged.
+- **Good (12-16):** Model runs with some functionality, but may have limitations or require further refinement. LoRA training is attempted but may not be fully successful. Attempts to evaluate the model, but the evaluation dataset may be limited or the process not fully thought through.
+- **Fair (8-12):** Significant issues or doesn't produce reliable outputs. LoRA training is attempted but unsuccessful. Minimal or no attempt to evaluate the model.
+- **Poor (0-8):** No functional model. No attempt to evaluate the model.
+
+### Innovation & Creativity (20 Points)
+
+- **Excellent (16-20):** The project shows a definite stretch of the students skills and expertise. Demonstrates a clear understanding of where the field currently sits and how it can be improved.
+- **Good (12-16):** Basic innovation is shown, but may not fully stretch the student's capabilities in this space. Creativity is shown, but mostly within the comfort zone.
+- **Fair (8-12):** Limited or no creativity shown. Almost exclusively stayed in comfort zone.
+- **Poor (0-8):** No innovation or creativity shown.
+
+## II. Production Environment & Programmability (30 Points)
+
+### Environment Setup (15 Points)
+
+- **Excellent (12-15):** Model is successfully deployed in a chosen production environment (local, AWS, etc.). The environment is configured correctly and the model is accessible via an API endpoint.
+- **Good (8-12):** Environment setup is partially successful, but may require some manual intervention or troubleshooting.
+- **Fair (4-8):** Significant difficulties in setting up the production environment.
+- **Poor (0-4):** Unable to set up a functional production environment.
+
+### Inference Pipeline (15 Points)
+
+- **Excellent (12-15):** A robust and efficient inference pipeline is established, allowing for calls to the model. The pipeline is well-documented and optimized for performance. Includes appropriate sampling method.
+- **Good (8-12):** Basic inference pipeline is implemented, but may have limitations or require further refinement. Sampling method is implemented but basic.
+- **Fair (4-8):** Rudimentary inference pipeline with limited functionality.
+- **Poor (0-4):** No functional inference pipeline.
+
+## III. Documentation & Presentation (30 Points)
+
+### Technical Documentation (15 Points)
+
+- **Excellent (12-15):** Comprehensive documentation of the entire system -- model, inference pipeline, API, deployment process, and sampling method.
+- **Good (8-12):** Good documentation, but may have some gaps.
+- **Fair (4-8):** Rudimentary documentation.
+- **Poor (0-4):** Little to no documentation.
+
+### Demo & Presentation (15 Points)
+
+- **Excellent (12-15):** Clear, concise, and engaging demonstration of the project.
+- **Good (8-12):** Adequate demonstration with some explanation.
+- **Fair (4-8):** Basic demonstration with limited explanation.
+- **Poor (0-4):** Unclear or incomplete demonstration.

--- a/src/design-system/components/flex-present-layout/index.tsx
+++ b/src/design-system/components/flex-present-layout/index.tsx
@@ -1,0 +1,36 @@
+import type { Child, FC, PropsWithChildren } from 'hono/jsx'
+import { resolveUrl } from '../../../shared/base-path'
+
+interface PresentLayoutProps {
+  title?: string
+  nav?: Child
+}
+
+export const PresentLayout: FC<PropsWithChildren<PresentLayoutProps>> = (
+  props,
+) => {
+  const title = props.title ? `${props.title} | Forms Lab` : 'Forms Lab'
+
+  return (
+    <html lang="en" data-theme="auto">
+      <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>{title}</title>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){var t=localStorage.getItem('theme');if(t==='light'||t==='dark'||t==='auto')document.documentElement.setAttribute('data-theme',t)})()`,
+          }}
+        />
+        <link rel="stylesheet" href={resolveUrl('/static/styles.css')} />
+      </head>
+      <body>
+        <main class="flex-present-layout">
+          <div class="flex-present-layout__content">{props.children}</div>
+          {props.nav && <div class="flex-present-layout__nav">{props.nav}</div>}
+        </main>
+        <script type="module" src={resolveUrl('/static/components.js')} />
+      </body>
+    </html>
+  )
+}

--- a/src/design-system/components/flex-present-layout/styles.css
+++ b/src/design-system/components/flex-present-layout/styles.css
@@ -7,7 +7,7 @@
 
 .flex-present-layout__content {
   flex: 1;
-  max-inline-size: 50rem;
+  max-inline-size: var(--flex-content-default);
   margin-inline: auto;
   inline-size: 100%;
 }
@@ -32,7 +32,7 @@
 }
 
 .flex-present-layout__nav {
-  max-inline-size: 50rem;
+  max-inline-size: var(--flex-content-default);
   margin-inline: auto;
   inline-size: 100%;
 }

--- a/src/design-system/components/flex-present-layout/styles.css
+++ b/src/design-system/components/flex-present-layout/styles.css
@@ -1,0 +1,43 @@
+.flex-present-layout {
+  display: flex;
+  flex-direction: column;
+  min-block-size: 100dvh;
+  padding: var(--flex-space-xl) var(--flex-space-lg);
+}
+
+.flex-present-layout__content {
+  flex: 1;
+  max-inline-size: 50rem;
+  margin-inline: auto;
+  inline-size: 100%;
+}
+
+.flex-present-layout__content .prose {
+  font-size: var(--flex-text-lg);
+  line-height: 1.6;
+}
+
+.flex-present-layout__content .prose h1 {
+  font-size: var(--flex-text-3xl);
+  margin-block-end: var(--flex-space-lg);
+}
+
+.flex-present-layout__content .prose h2 {
+  font-size: var(--flex-text-2xl);
+  margin-block-start: var(--flex-space-xl);
+}
+
+.flex-present-layout__content .prose a {
+  text-decoration: underline;
+}
+
+.flex-present-layout__nav {
+  max-inline-size: 50rem;
+  margin-inline: auto;
+  inline-size: 100%;
+}
+
+.flex-present-layout .flex-walkthrough-nav {
+  border-block-start: none;
+  margin-block-start: 0;
+}

--- a/src/design-system/components/flex-walkthrough-nav/index.tsx
+++ b/src/design-system/components/flex-walkthrough-nav/index.tsx
@@ -1,0 +1,43 @@
+import type { FC } from 'hono/jsx'
+
+interface WalkthroughNavProps {
+  currentPage: number
+  totalPages: number
+  prevUrl: string | null
+  nextUrl: string | null
+}
+
+export const WalkthroughNav: FC<WalkthroughNavProps> = ({
+  currentPage,
+  totalPages,
+  prevUrl,
+  nextUrl,
+}) => {
+  return (
+    <nav class="flex-walkthrough-nav" aria-label="Walkthrough navigation">
+      <span class="flex-walkthrough-nav__progress">
+        {currentPage} of {totalPages}
+      </span>
+      <div class="flex-walkthrough-nav__controls">
+        {prevUrl ? (
+          <a href={prevUrl} class="flex-walkthrough-nav__link">
+            ← Previous
+          </a>
+        ) : (
+          <span class="flex-walkthrough-nav__link" data-disabled>
+            ← Previous
+          </span>
+        )}
+        {nextUrl ? (
+          <a href={nextUrl} class="flex-walkthrough-nav__link">
+            Next →
+          </a>
+        ) : (
+          <span class="flex-walkthrough-nav__link" data-disabled>
+            Next →
+          </span>
+        )}
+      </div>
+    </nav>
+  )
+}

--- a/src/design-system/components/flex-walkthrough-nav/styles.css
+++ b/src/design-system/components/flex-walkthrough-nav/styles.css
@@ -1,0 +1,33 @@
+.flex-walkthrough-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-block: var(--flex-space-md);
+  border-block-start: 1px solid var(--flex-color-border);
+  margin-block-start: var(--flex-space-lg);
+}
+
+.flex-walkthrough-nav__progress {
+  font-size: var(--flex-text-sm);
+  color: var(--flex-color-text-muted);
+}
+
+.flex-walkthrough-nav__controls {
+  display: flex;
+  gap: var(--flex-space-md);
+}
+
+.flex-walkthrough-nav__link {
+  color: var(--flex-color-accent);
+  text-decoration: none;
+  font-weight: 700;
+}
+
+.flex-walkthrough-nav__link:hover {
+  text-decoration: underline;
+}
+
+.flex-walkthrough-nav__link[data-disabled] {
+  color: var(--flex-color-text-muted);
+  pointer-events: none;
+}

--- a/src/entrypoints/app/public/styles.css
+++ b/src/entrypoints/app/public/styles.css
@@ -75,6 +75,7 @@
 @import "../../../design-system/components/flex-strategy-selector/styles.css" layer(block);
 @import "../routes/projects/styles.css" layer(block);
 @import "../../../design-system/components/flex-walkthrough-nav/styles.css" layer(block);
+@import "../../../design-system/components/flex-present-layout/styles.css" layer(block);
 
 /* Utility */
 @import "./utilities.css" layer(utility);

--- a/src/entrypoints/app/public/styles.css
+++ b/src/entrypoints/app/public/styles.css
@@ -74,6 +74,7 @@
 @import "../../dashboard/deployment-table.css" layer(block);
 @import "../../../design-system/components/flex-strategy-selector/styles.css" layer(block);
 @import "../routes/projects/styles.css" layer(block);
+@import "../../../design-system/components/flex-walkthrough-nav/styles.css" layer(block);
 
 /* Utility */
 @import "./utilities.css" layer(utility);

--- a/src/entrypoints/app/routes/catalog/index.tsx
+++ b/src/entrypoints/app/routes/catalog/index.tsx
@@ -66,6 +66,17 @@ catalog.get('/', async (c) => {
 
       <div class="l-stack" style="--stack-space: var(--flex-space-xl)">
         <section>
+          <p class="catalog-group-label">Presentation</p>
+          <div class="l-grid" style="--grid-min: 280px">
+            <ContentCard
+              title="Walkthrough"
+              href={resolveUrl('/catalog/walkthrough')}
+              description="Guided tour of the project — problem, approach, LLM integration, and demo"
+            />
+          </div>
+        </section>
+
+        <section>
           <p class="catalog-group-label">The System</p>
           <div class="l-grid" style="--grid-min: 280px">
             <ContentCard

--- a/src/entrypoints/app/routes/catalog/index.tsx
+++ b/src/entrypoints/app/routes/catalog/index.tsx
@@ -12,6 +12,7 @@ import experiments from './experiments'
 import personas from './personas'
 import { getCatalogSidebar } from './sidebar'
 import stories from './stories'
+import walkthrough from './walkthrough'
 
 const catalog = new Hono()
 
@@ -22,6 +23,7 @@ catalog.route('/architecture', architecture)
 catalog.route('/stories', stories)
 catalog.route('/experiments', experiments)
 catalog.route('/design-system', designSystem)
+catalog.route('/walkthrough', walkthrough)
 
 // Catalog landing page
 catalog.get('/', async (c) => {

--- a/src/entrypoints/app/routes/catalog/sidebar.ts
+++ b/src/entrypoints/app/routes/catalog/sidebar.ts
@@ -1,5 +1,5 @@
 import { getComponentsByCategory } from '../../../../design-system/registry'
-import type { Decision, Story } from '../../../../services/content/types'
+import type { Decision, Story, WalkthroughPage } from '../../../../services/content/types'
 import { resolveUrl } from '../../../../shared/base-path'
 
 export function getCatalogSidebar(currentPath?: string) {
@@ -11,6 +11,16 @@ export function getCatalogSidebar(currentPath?: string) {
           label: 'Overview',
           href: resolveUrl('/catalog'),
           current: currentPath === '/catalog',
+        },
+      ],
+    },
+    {
+      title: 'Presentation',
+      items: [
+        {
+          label: 'Walkthrough',
+          href: resolveUrl('/catalog/walkthrough'),
+          current: currentPath === '/catalog/walkthrough',
         },
       ],
     },
@@ -251,6 +261,37 @@ export function getStoriesSidebar(stories: Story[], currentPath?: string) {
           label: `#${s.issue} ${s.title}`,
           href: resolveUrl(`/catalog/stories/${s.slug}`),
           current: currentPath === `/catalog/stories/${s.slug}`,
+        })),
+      ],
+    },
+  ]
+}
+
+/**
+ * Contextual sidebar for walkthrough pages.
+ */
+export function getWalkthroughSidebar(
+  pages: WalkthroughPage[],
+  currentPath?: string,
+) {
+  return [
+    {
+      title: 'Walkthrough',
+      items: [
+        {
+          label: '\u2190 Back to Catalog',
+          href: resolveUrl('/catalog'),
+          current: false,
+        },
+        {
+          label: 'Overview',
+          href: resolveUrl('/catalog/walkthrough'),
+          current: currentPath === '/catalog/walkthrough',
+        },
+        ...pages.map((p, i) => ({
+          label: `${i + 1}. ${p.title}`,
+          href: resolveUrl(`/catalog/walkthrough/${p.slug}`),
+          current: currentPath === `/catalog/walkthrough/${p.slug}`,
         })),
       ],
     },

--- a/src/entrypoints/app/routes/catalog/sidebar.ts
+++ b/src/entrypoints/app/routes/catalog/sidebar.ts
@@ -1,5 +1,9 @@
 import { getComponentsByCategory } from '../../../../design-system/registry'
-import type { Decision, Story, WalkthroughPage } from '../../../../services/content/types'
+import type {
+  Decision,
+  Story,
+  WalkthroughPage,
+} from '../../../../services/content/types'
 import { resolveUrl } from '../../../../shared/base-path'
 
 export function getCatalogSidebar(currentPath?: string) {

--- a/src/entrypoints/app/routes/catalog/walkthrough.tsx
+++ b/src/entrypoints/app/routes/catalog/walkthrough.tsx
@@ -13,7 +13,7 @@ import {
 } from '../../../../services/content/markdown'
 import type { WalkthroughPage } from '../../../../services/content/types'
 import { resolveUrl } from '../../../../shared/base-path'
-import { getCatalogSidebar } from './sidebar'
+import { getCatalogSidebar, getWalkthroughSidebar } from './sidebar'
 
 const walkthrough = new Hono()
 
@@ -66,7 +66,7 @@ walkthrough.get('/', async (c) => {
     return sum + (match ? parseInt(match[1], 10) : 0)
   }, 0)
 
-  const sidebarData = getCatalogSidebar('/catalog/walkthrough')
+  const sidebarData = getWalkthroughSidebar(pages, '/catalog/walkthrough')
   const sidebar = <CatalogSidebar sections={sidebarData} />
 
   const firstPage = pages[0]
@@ -136,7 +136,7 @@ walkthrough.get('/:slug', async (c) => {
   const pageIndex = pages.findIndex((p) => p.slug === slug)
 
   if (pageIndex === -1) {
-    const sidebarData = getCatalogSidebar('/catalog/walkthrough')
+    const sidebarData = getWalkthroughSidebar(pages, `/catalog/walkthrough/${slug}`)
     const sidebar = <CatalogSidebar sections={sidebarData} />
     return c.html(
       <Layout
@@ -156,7 +156,7 @@ walkthrough.get('/:slug', async (c) => {
   const prevPage = pageIndex > 0 ? pages[pageIndex - 1] : null
   const nextPage = pageIndex < pages.length - 1 ? pages[pageIndex + 1] : null
 
-  const sidebarData = getCatalogSidebar('/catalog/walkthrough')
+  const sidebarData = getWalkthroughSidebar(pages, `/catalog/walkthrough/${slug}`)
   const sidebar = <CatalogSidebar sections={sidebarData} />
 
   return c.html(

--- a/src/entrypoints/app/routes/catalog/walkthrough.tsx
+++ b/src/entrypoints/app/routes/catalog/walkthrough.tsx
@@ -4,6 +4,7 @@ import { Breadcrumb } from '../../../../design-system/components/flex-breadcrumb
 import { ContentCard } from '../../../../design-system/components/flex-card'
 import { CatalogSidebar } from '../../../../design-system/components/flex-catalog-sidebar'
 import { Layout } from '../../../../design-system/components/flex-layout'
+import { PresentLayout } from '../../../../design-system/components/flex-present-layout'
 import { Prose } from '../../../../design-system/components/flex-prose'
 import { TagList } from '../../../../design-system/components/flex-tag-list'
 import { WalkthroughNav } from '../../../../design-system/components/flex-walkthrough-nav'
@@ -13,7 +14,7 @@ import {
 } from '../../../../services/content/markdown'
 import type { WalkthroughPage } from '../../../../services/content/types'
 import { resolveUrl } from '../../../../shared/base-path'
-import { getCatalogSidebar, getWalkthroughSidebar } from './sidebar'
+import { getWalkthroughSidebar } from './sidebar'
 
 const walkthrough = new Hono()
 
@@ -66,10 +67,46 @@ walkthrough.get('/', async (c) => {
     return sum + (match ? parseInt(match[1], 10) : 0)
   }, 0)
 
+  const firstPage = pages[0]
+
+  const isPresent = c.req.query('present') !== undefined
+
+  if (isPresent) {
+    const firstUrl = firstPage
+      ? resolveUrl(`/catalog/walkthrough/${firstPage.slug}?present`)
+      : null
+
+    return c.html(
+      <PresentLayout title="Walkthrough">
+        <div style="display:flex;flex-direction:column;align-items:center;justify-content:center;min-height:60vh;text-align:center">
+          <h1 style="font-size:var(--flex-text-3xl);margin-block-end:var(--flex-space-md)">
+            Forms Lab
+          </h1>
+          <p style="font-size:var(--flex-text-xl);color:var(--flex-color-text-muted);margin-block-end:var(--flex-space-xl)">
+            LLM-Assisted Forms Platform for Government
+          </p>
+          {firstUrl && (
+            <a href={firstUrl} class="flex-button" data-size="big">
+              Begin →
+            </a>
+          )}
+          <p style="font-size:var(--flex-text-sm);color:var(--flex-color-text-muted);margin-block-start:var(--flex-space-lg)">
+            Press → or click to begin
+          </p>
+        </div>
+        {firstUrl && (
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `document.addEventListener('keydown',function(e){if(e.key==='ArrowRight'||e.key===' '){e.preventDefault();location.href='${firstUrl}'}})`,
+            }}
+          />
+        )}
+      </PresentLayout>,
+    )
+  }
+
   const sidebarData = getWalkthroughSidebar(pages, '/catalog/walkthrough')
   const sidebar = <CatalogSidebar sections={sidebarData} />
-
-  const firstPage = pages[0]
 
   return c.html(
     <Layout
@@ -136,7 +173,10 @@ walkthrough.get('/:slug', async (c) => {
   const pageIndex = pages.findIndex((p) => p.slug === slug)
 
   if (pageIndex === -1) {
-    const sidebarData = getWalkthroughSidebar(pages, `/catalog/walkthrough/${slug}`)
+    const sidebarData = getWalkthroughSidebar(
+      pages,
+      `/catalog/walkthrough/${slug}`,
+    )
     const sidebar = <CatalogSidebar sections={sidebarData} />
     return c.html(
       <Layout
@@ -156,7 +196,53 @@ walkthrough.get('/:slug', async (c) => {
   const prevPage = pageIndex > 0 ? pages[pageIndex - 1] : null
   const nextPage = pageIndex < pages.length - 1 ? pages[pageIndex + 1] : null
 
-  const sidebarData = getWalkthroughSidebar(pages, `/catalog/walkthrough/${slug}`)
+  const isPresent = c.req.query('present') !== undefined
+
+  if (isPresent) {
+    const prevUrl = prevPage
+      ? resolveUrl(`/catalog/walkthrough/${prevPage.slug}?present`)
+      : null
+    const nextUrl = nextPage
+      ? resolveUrl(`/catalog/walkthrough/${nextPage.slug}?present`)
+      : null
+
+    return c.html(
+      <PresentLayout
+        title={page.title}
+        nav={
+          <WalkthroughNav
+            currentPage={pageIndex + 1}
+            totalPages={pages.length}
+            prevUrl={prevUrl}
+            nextUrl={nextUrl}
+          />
+        }
+      >
+        <Prose html={renderMarkdown(page.content)} />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){
+            var prev=${prevUrl ? `"${prevUrl}"` : 'null'};
+            var next=${nextUrl ? `"${nextUrl}"` : 'null'};
+            document.addEventListener('keydown',function(e){
+              if(e.key==='ArrowRight'||e.key===' '){if(next){e.preventDefault();location.href=next}}
+              if(e.key==='ArrowLeft'){if(prev){e.preventDefault();location.href=prev}}
+              if(e.key==='Escape'){location.href='${resolveUrl('/catalog/walkthrough')}'}
+            });
+            document.querySelectorAll('.prose a').forEach(function(a){
+              if(!a.getAttribute('href').startsWith('#'))a.setAttribute('target','_blank')
+            });
+          }())`,
+          }}
+        />
+      </PresentLayout>,
+    )
+  }
+
+  const sidebarData = getWalkthroughSidebar(
+    pages,
+    `/catalog/walkthrough/${slug}`,
+  )
   const sidebar = <CatalogSidebar sections={sidebarData} />
 
   return c.html(

--- a/src/entrypoints/app/routes/catalog/walkthrough.tsx
+++ b/src/entrypoints/app/routes/catalog/walkthrough.tsx
@@ -1,0 +1,127 @@
+import { join } from 'node:path'
+import { Hono } from 'hono'
+import { ContentCard } from '../../../../design-system/components/flex-card'
+import { CatalogSidebar } from '../../../../design-system/components/flex-catalog-sidebar'
+import { Layout } from '../../../../design-system/components/flex-layout'
+import { TagList } from '../../../../design-system/components/flex-tag-list'
+import { readMarkdownDir } from '../../../../services/content/markdown'
+import type { WalkthroughPage } from '../../../../services/content/types'
+import { resolveUrl } from '../../../../shared/base-path'
+import { getCatalogSidebar } from './sidebar'
+
+const walkthrough = new Hono()
+
+function parseArrayField(value: string | undefined): string[] {
+  if (!value) return []
+  return value
+    .replace(/[[\]]/g, '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+}
+
+function parseWalkthroughPage(file: {
+  frontmatter: Record<string, string>
+  content: string
+  filename: string
+}): WalkthroughPage {
+  return {
+    slug: file.filename,
+    title: file.frontmatter.title || file.filename,
+    order: parseInt(file.frontmatter.order || '0', 10),
+    rubric: parseArrayField(file.frontmatter.rubric),
+    timing: file.frontmatter.timing || '',
+    audience: parseArrayField(file.frontmatter.audience),
+    content: file.content,
+  }
+}
+
+async function loadWalkthroughPages(): Promise<WalkthroughPage[]> {
+  const dir = join(process.cwd(), 'catalog', 'walkthrough')
+  const files = await readMarkdownDir(dir)
+  return files.map(parseWalkthroughPage).sort((a, b) => a.order - b.order)
+}
+
+const RUBRIC_AREAS = [
+  'model-functionality',
+  'innovation',
+  'environment-setup',
+  'inference-pipeline',
+  'technical-documentation',
+  'demo-presentation',
+] as const
+
+walkthrough.get('/', async (c) => {
+  const pages = await loadWalkthroughPages()
+
+  const coveredAreas = new Set(pages.flatMap((p) => p.rubric))
+  const totalMinutes = pages.reduce((sum, p) => {
+    const match = p.timing.match(/(\d+)/)
+    return sum + (match ? parseInt(match[1], 10) : 0)
+  }, 0)
+
+  const sidebarData = getCatalogSidebar('/catalog/walkthrough')
+  const sidebar = <CatalogSidebar sections={sidebarData} />
+
+  const firstPage = pages[0]
+
+  return c.html(
+    <Layout
+      title="Walkthrough"
+      sidebar={sidebar}
+      currentPath="/catalog"
+      user={c.get('user')}
+    >
+      <h1>Project Walkthrough</h1>
+      <p>
+        A guided tour of the Forms Lab project — problem, approach, LLM
+        integration, production environment, and live demo.
+        {totalMinutes > 0 && <> Estimated time: {totalMinutes} minutes.</>}
+      </p>
+
+      {firstPage && (
+        <p>
+          <a
+            href={resolveUrl(`/catalog/walkthrough/${firstPage.slug}`)}
+            class="flex-button"
+          >
+            Start walkthrough
+          </a>
+        </p>
+      )}
+
+      <section>
+        <h2>Rubric Coverage</h2>
+        <div class="l-cluster">
+          {RUBRIC_AREAS.map((area) => (
+            <span
+              key={area}
+              class="badge"
+              data-status={coveredAreas.has(area) ? 'closed' : 'open'}
+            >
+              {area}
+            </span>
+          ))}
+        </div>
+      </section>
+
+      <section>
+        <h2>Sections</h2>
+        <div class="l-stack">
+          {pages.map((page, i) => (
+            <ContentCard
+              key={page.slug}
+              title={`${i + 1}. ${page.title}`}
+              href={resolveUrl(`/catalog/walkthrough/${page.slug}`)}
+              description={page.timing ? `${page.timing}` : undefined}
+            >
+              <TagList tags={page.rubric} />
+            </ContentCard>
+          ))}
+        </div>
+      </section>
+    </Layout>,
+  )
+})
+
+export default walkthrough

--- a/src/entrypoints/app/routes/catalog/walkthrough.tsx
+++ b/src/entrypoints/app/routes/catalog/walkthrough.tsx
@@ -1,10 +1,16 @@
 import { join } from 'node:path'
 import { Hono } from 'hono'
+import { Breadcrumb } from '../../../../design-system/components/flex-breadcrumb'
 import { ContentCard } from '../../../../design-system/components/flex-card'
 import { CatalogSidebar } from '../../../../design-system/components/flex-catalog-sidebar'
 import { Layout } from '../../../../design-system/components/flex-layout'
+import { Prose } from '../../../../design-system/components/flex-prose'
 import { TagList } from '../../../../design-system/components/flex-tag-list'
-import { readMarkdownDir } from '../../../../services/content/markdown'
+import { WalkthroughNav } from '../../../../design-system/components/flex-walkthrough-nav'
+import {
+  readMarkdownDir,
+  renderMarkdown,
+} from '../../../../services/content/markdown'
 import type { WalkthroughPage } from '../../../../services/content/types'
 import { resolveUrl } from '../../../../shared/base-path'
 import { getCatalogSidebar } from './sidebar'
@@ -120,6 +126,64 @@ walkthrough.get('/', async (c) => {
           ))}
         </div>
       </section>
+    </Layout>,
+  )
+})
+
+walkthrough.get('/:slug', async (c) => {
+  const slug = c.req.param('slug')
+  const pages = await loadWalkthroughPages()
+  const pageIndex = pages.findIndex((p) => p.slug === slug)
+
+  if (pageIndex === -1) {
+    const sidebarData = getCatalogSidebar('/catalog/walkthrough')
+    const sidebar = <CatalogSidebar sections={sidebarData} />
+    return c.html(
+      <Layout
+        title="Not Found"
+        sidebar={sidebar}
+        currentPath="/catalog"
+        user={c.get('user')}
+      >
+        <h1>Page Not Found</h1>
+        <p>The walkthrough page "{slug}" does not exist.</p>
+      </Layout>,
+      404,
+    )
+  }
+
+  const page = pages[pageIndex]
+  const prevPage = pageIndex > 0 ? pages[pageIndex - 1] : null
+  const nextPage = pageIndex < pages.length - 1 ? pages[pageIndex + 1] : null
+
+  const sidebarData = getCatalogSidebar('/catalog/walkthrough')
+  const sidebar = <CatalogSidebar sections={sidebarData} />
+
+  return c.html(
+    <Layout
+      title={page.title}
+      sidebar={sidebar}
+      currentPath="/catalog"
+      user={c.get('user')}
+    >
+      <Breadcrumb
+        items={[
+          { label: 'Catalog', href: resolveUrl('/catalog') },
+          { label: 'Walkthrough', href: resolveUrl('/catalog/walkthrough') },
+          { label: page.title },
+        ]}
+      />
+      <Prose html={renderMarkdown(page.content)} />
+      <WalkthroughNav
+        currentPage={pageIndex + 1}
+        totalPages={pages.length}
+        prevUrl={
+          prevPage ? resolveUrl(`/catalog/walkthrough/${prevPage.slug}`) : null
+        }
+        nextUrl={
+          nextPage ? resolveUrl(`/catalog/walkthrough/${nextPage.slug}`) : null
+        }
+      />
     </Layout>,
   )
 })

--- a/src/entrypoints/app/routes/catalog/walkthrough.tsx
+++ b/src/entrypoints/app/routes/catalog/walkthrough.tsx
@@ -230,7 +230,7 @@ walkthrough.get('/:slug', async (c) => {
               if(e.key==='Escape'){location.href='${resolveUrl('/catalog/walkthrough')}'}
             });
             document.querySelectorAll('.prose a').forEach(function(a){
-              if(!a.getAttribute('href').startsWith('#'))a.setAttribute('target','_blank')
+              var h=a.getAttribute('href');if(h&&!h.startsWith('#'))a.setAttribute('target','_blank')
             });
           }())`,
           }}

--- a/src/services/content/types.ts
+++ b/src/services/content/types.ts
@@ -44,3 +44,13 @@ export interface Story {
   syncedAt: string
   content: string
 }
+
+export interface WalkthroughPage {
+  slug: string
+  title: string
+  order: number
+  rubric: string[]
+  timing: string
+  audience: string[]
+  content: string
+}

--- a/test/catalog-walkthrough.test.ts
+++ b/test/catalog-walkthrough.test.ts
@@ -49,4 +49,38 @@ describe('Walkthrough Routes', () => {
       expect(body).toContain('← Back to Catalog')
     })
   })
+
+  describe('Present mode', () => {
+    it('returns 200 for walkthrough page in present mode', async () => {
+      const res = await app.request(
+        '/catalog/walkthrough/01-the-problem?present',
+      )
+      expect(res.status).toBe(200)
+    })
+
+    it('does not render catalog header in present mode', async () => {
+      const res = await app.request(
+        '/catalog/walkthrough/01-the-problem?present',
+      )
+      const body = await res.text()
+      expect(body).not.toContain('flex-header')
+      expect(body).toContain('flex-present-layout')
+      expect(body).toContain('The Problem')
+    })
+
+    it('includes keyboard navigation script in present mode', async () => {
+      const res = await app.request(
+        '/catalog/walkthrough/01-the-problem?present',
+      )
+      const body = await res.text()
+      expect(body).toContain('ArrowRight')
+    })
+
+    it('renders index as title slide in present mode', async () => {
+      const res = await app.request('/catalog/walkthrough?present')
+      expect(res.status).toBe(200)
+      const body = await res.text()
+      expect(body).toContain('flex-present-layout')
+    })
+  })
 })

--- a/test/catalog-walkthrough.test.ts
+++ b/test/catalog-walkthrough.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'bun:test'
+import app from '../src/entrypoints/app/server'
+
+describe('Walkthrough Routes', () => {
+  describe('GET /catalog/walkthrough', () => {
+    it('returns 200 and lists walkthrough pages', async () => {
+      const res = await app.request('/catalog/walkthrough')
+      expect(res.status).toBe(200)
+
+      const body = await res.text()
+      expect(body).toContain('Walkthrough')
+      expect(body).toContain('The Problem')
+    })
+  })
+})

--- a/test/catalog-walkthrough.test.ts
+++ b/test/catalog-walkthrough.test.ts
@@ -12,4 +12,26 @@ describe('Walkthrough Routes', () => {
       expect(body).toContain('The Problem')
     })
   })
+
+  describe('GET /catalog/walkthrough/:slug', () => {
+    it('returns 200 and renders walkthrough page', async () => {
+      const res = await app.request('/catalog/walkthrough/01-the-problem')
+      expect(res.status).toBe(200)
+
+      const body = await res.text()
+      expect(body).toContain('The Problem')
+      expect(body).toContain('Government Forms')
+    })
+
+    it('shows progress indicator', async () => {
+      const res = await app.request('/catalog/walkthrough/01-the-problem')
+      const body = await res.text()
+      expect(body).toContain('1 of')
+    })
+
+    it('returns 404 for unknown slug', async () => {
+      const res = await app.request('/catalog/walkthrough/nonexistent')
+      expect(res.status).toBe(404)
+    })
+  })
 })

--- a/test/catalog-walkthrough.test.ts
+++ b/test/catalog-walkthrough.test.ts
@@ -83,4 +83,30 @@ describe('Walkthrough Routes', () => {
       expect(body).toContain('flex-present-layout')
     })
   })
+
+  describe('All walkthrough pages render', () => {
+    const slugs = [
+      '01-the-problem',
+      '02-our-approach',
+      '03-llm-assisted-extraction',
+      '04-evaluation-and-experimentation',
+      '05-production-infrastructure',
+      '06-inference-pipeline',
+      '07-live-demo',
+      '08-whats-next',
+    ]
+
+    for (const slug of slugs) {
+      it(`renders ${slug}`, async () => {
+        const res = await app.request(`/catalog/walkthrough/${slug}`)
+        expect(res.status).toBe(200)
+      })
+    }
+
+    it('shows correct total page count in navigation', async () => {
+      const res = await app.request('/catalog/walkthrough/01-the-problem')
+      const body = await res.text()
+      expect(body).toContain('1 of 8')
+    })
+  })
 })

--- a/test/catalog-walkthrough.test.ts
+++ b/test/catalog-walkthrough.test.ts
@@ -34,4 +34,19 @@ describe('Walkthrough Routes', () => {
       expect(res.status).toBe(404)
     })
   })
+
+  describe('Sidebar Integration', () => {
+    it('shows walkthrough link in catalog sidebar', async () => {
+      const res = await app.request('/catalog')
+      const body = await res.text()
+      expect(body).toContain('Walkthrough')
+      expect(body).toContain('/catalog/walkthrough')
+    })
+
+    it('shows contextual sidebar on walkthrough pages', async () => {
+      const res = await app.request('/catalog/walkthrough/01-the-problem')
+      const body = await res.text()
+      expect(body).toContain('← Back to Catalog')
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Adds a guided walkthrough content type to the catalog that serves as both a browsable project overview and a live presentation tool. Closes #48.

- **Walkthrough as catalog content type** -- 8 markdown pages in `catalog/walkthrough/` with frontmatter for order, rubric coverage tags, timing, and audience
- **Dual rendering modes** -- normal catalog view (sidebar, breadcrumbs, full chrome) and presentation mode (`?present`) with minimal chrome, focused typography, and keyboard navigation
- **Rubric coverage tracking** -- index page aggregates rubric tags from all pages and shows which of the 6 grading areas are covered

## How it works

- `/catalog/walkthrough` -- index page with section list, rubric coverage summary, and "Start" button
- `/catalog/walkthrough/:slug` -- individual page with prev/next navigation and progress indicator ("3 of 8")
- `/catalog/walkthrough?present` -- title slide; `/catalog/walkthrough/:slug?present` -- focused presentation view
- Arrow keys, spacebar, and escape navigate in present mode; external links open in new tabs

## Content

8 sections covering the project as built to date, weighted to match the rubric (40% LLM, 30% production/pipeline, 30% docs/demo):

1. The Problem (1 min)
2. Our Approach (2 min) -- innovation
3. LLM-Assisted Extraction (3 min) -- model-functionality, innovation
4. Evaluation & Experimentation (3 min) -- model-functionality
5. Production Infrastructure (2 min) -- environment-setup
6. Inference Pipeline (2 min) -- inference-pipeline
7. Live Demo (2 min) -- demo-presentation
8. What's Next (1 min)

## New components

- `flex-walkthrough-nav` -- prev/next navigation with progress indicator
- `flex-present-layout` -- minimal-chrome layout for presentation mode

## Test plan

- [ ] 19 integration tests pass (index, detail, 404, sidebar, present mode, all 8 pages, page count)
- [ ] Visit `/catalog/walkthrough` -- index shows sections, timing, rubric badges, "Start" button
- [ ] Click through all pages -- prev/next navigation works, progress updates
- [ ] Sidebar shows "← Back to Catalog", overview link, numbered page list
- [ ] Visit `/catalog/walkthrough?present` -- title slide, "Begin →" button
- [ ] Click through present mode -- minimal chrome, no header/footer/sidebar
- [ ] Test keyboard: → advances, ← goes back, Space advances, Escape exits
- [ ] Links in present mode open in new tabs
- [ ] Catalog landing page shows "Walkthrough" card in Presentation section