### PR TITLE
infra: reboot-safe branch apps + webhook mid-build recovery

### DIFF
--- a/infrastructure/nixos/configuration.nix
+++ b/infrastructure/nixos/configuration.nix
@@ -86,6 +86,15 @@
       command = "${pkgs.systemd}/bin/systemctl stop forms-lab-app@*";
       options = [ "NOPASSWD" ];
     } {
+      # Enable/disable per-instance template units so they survive reboots.
+      # Template units cannot be wantedBy multi-user.target as a whole —
+      # each instance must be individually symlinked.
+      command = "${pkgs.systemd}/bin/systemctl enable forms-lab-app@*";
+      options = [ "NOPASSWD" ];
+    } {
+      command = "${pkgs.systemd}/bin/systemctl disable forms-lab-app@*";
+      options = [ "NOPASSWD" ];
+    } {
       command = "${pkgs.systemd}/bin/systemctl restart forms-lab-homepage.service";
       options = [ "NOPASSWD" ];
     } {

--- a/infrastructure/nixos/modules/app.nix
+++ b/infrastructure/nixos/modules/app.nix
@@ -20,8 +20,17 @@
       Restart = "on-failure";
       RestartSec = 5;
 
+      # Flap control: if the unit fails 5 times within 5 minutes, stop
+      # retrying and leave it in a failed state instead of burning CPU.
+      # systemd interprets these at the [Unit]/[Service] level — NixOS
+      # exposes them via startLimit* keys on the service attrset.
+
       # Environment loaded from a per-branch env file written by deploy script
       EnvironmentFile = "/srv/forms-lab/%i/.env";
     };
+
+    # Flap control — prevents a broken branch from retrying forever.
+    startLimitBurst = 5;
+    startLimitIntervalSec = 300;
   };
 }

--- a/infrastructure/nixos/modules/deploy.nix
+++ b/infrastructure/nixos/modules/deploy.nix
@@ -53,6 +53,42 @@ let
 
     echo "Deploying $BRANCH at $SHA..."
 
+    # --- Lockfile + stale-build recovery -----------------------------------
+    # If the previous deploy process crashed (OOM, kernel panic, host reboot
+    # mid-build) the worktree can be left with:
+    #   - a lingering .deploy-in-progress lockfile
+    #   - a partially-built dist/ directory
+    # On the *next* push we treat a lockfile older than 10 minutes as proof
+    # that the previous run is gone, and we wipe dist/ so the build starts
+    # clean. A fresh lockfile (< 10 minutes) means another deploy is actually
+    # running and we bail to avoid two processes stomping on each other.
+    LOCKFILE="$BRANCH_DIR/.deploy-in-progress"
+    STALE_AGE_SECONDS=600  # 10 minutes
+    if [ -d "$BRANCH_DIR" ] && [ -f "$LOCKFILE" ]; then
+      LOCK_MTIME=$(${pkgs.coreutils}/bin/stat -c %Y "$LOCKFILE" 2>/dev/null || echo 0)
+      NOW=$(${pkgs.coreutils}/bin/date +%s)
+      AGE=$((NOW - LOCK_MTIME))
+      if [ "$AGE" -gt "$STALE_AGE_SECONDS" ]; then
+        echo "Found stale lockfile (age $${AGE}s > $${STALE_AGE_SECONDS}s) — cleaning up partial build"
+        ${pkgs.coreutils}/bin/rm -f "$LOCKFILE"
+        ${pkgs.coreutils}/bin/rm -rf "$BRANCH_DIR/dist"
+      else
+        echo "ERROR: Fresh lockfile at $LOCKFILE (age $${AGE}s) — another deploy is in progress"
+        exit 1
+      fi
+    fi
+    # Make sure the lockfile is removed on any exit — normal, failure, signal.
+    # Trap is installed AFTER the stale-check above so we don't accidentally
+    # blow away a fresh lockfile belonging to a concurrent deploy that
+    # already exited with code 1 before its own trap fired.
+    cleanup_lockfile() {
+      if [ -n "''${LOCKFILE:-}" ] && [ -f "$LOCKFILE" ]; then
+        ${pkgs.coreutils}/bin/rm -f "$LOCKFILE"
+      fi
+    }
+    trap cleanup_lockfile EXIT
+    # -----------------------------------------------------------------------
+
     # Initialize bare repo if needed
     if [ ! -d "$REPO_DIR" ]; then
       ${pkgs.git}/bin/git clone --bare https://github.com/flexion/forms-lab.git "$REPO_DIR"
@@ -80,8 +116,15 @@ let
 
     cd "$BRANCH_DIR"
 
+    # Create the lockfile now that the worktree exists. Re-touch on each
+    # long-running step so the mtime reflects the currently-active phase,
+    # and the 10-minute stale threshold is measured from the last real
+    # progress rather than from deploy start.
+    ${pkgs.coreutils}/bin/touch "$LOCKFILE"
+
     # Install and build
     ${pkgs.bun}/bin/bun install
+    ${pkgs.coreutils}/bin/touch "$LOCKFILE"
 
     # Bootstrap guard: verify deploy.json entrypoints exist before building
     if [ -f "$BRANCH_DIR/deploy.json" ]; then
@@ -110,6 +153,7 @@ let
     fi
 
     ${pkgs.bun}/bin/bun run build
+    ${pkgs.coreutils}/bin/touch "$LOCKFILE"
 
     # Assign port — read from ports.json or assign next available
     if [ ! -f "$PORT_FILE" ]; then

--- a/infrastructure/nixos/modules/deploy.nix
+++ b/infrastructure/nixos/modules/deploy.nix
@@ -150,6 +150,14 @@ ENVEOF
     /run/wrappers/bin/sudo ${pkgs.systemd}/bin/systemctl restart "forms-lab-app@$UNIT_NAME.service" || \
       /run/wrappers/bin/sudo ${pkgs.systemd}/bin/systemctl start "forms-lab-app@$UNIT_NAME.service"
 
+    # Enable the instance so it survives reboots. Template units are not
+    # wantedBy multi-user.target on their own — each instance must be
+    # individually symlinked into multi-user.target.wants/. Without this,
+    # a reboot leaves branch apps dead until something explicitly starts
+    # them (which the webhook's startup recovery also handles as a
+    # belt-and-braces fallback).
+    /run/wrappers/bin/sudo ${pkgs.systemd}/bin/systemctl enable "forms-lab-app@$UNIT_NAME.service" || true
+
     # Write Caddy route snippet to persistent config directory
     CADDY_DIR="$DEPLOY_ROOT/caddy.d"
     mkdir -p "$CADDY_DIR"

--- a/notes/2026-04-19-infra-reboot-safe/design.md
+++ b/notes/2026-04-19-infra-reboot-safe/design.md
@@ -1,0 +1,90 @@
+---
+status: working
+---
+
+# Reboot-safe branch apps + webhook mid-build recovery
+
+Incident: 2026-04-19 ~15:49 UTC. Webhook deploy for `experiment/74-rag-extraction` was mid-build
+when the EC2 instance froze; a force-stop/start surfaced two problems:
+
+1. Branch app template units (`forms-lab-app@<branch>.service`) did not come back after reboot —
+   manual `systemctl start` was required for every branch app.
+2. A mid-build kill leaves the deploy in a half-state (stale `dist/`, no restart, no recovery trigger
+   until another push arrives).
+
+## Files to change
+
+### Fix 1 — Reboot-safe branch apps
+
+- `infrastructure/nixos/modules/app.nix`
+  - The template unit `forms-lab-app@.service` already has `Restart = "on-failure"` and `RestartSec = 5`,
+    but no flap control. Add `StartLimitBurst` and `StartLimitIntervalSec` so a broken branch does not
+    retry forever (systemd keeps the unit in a "failed" state instead).
+  - Template units cannot be `wantedBy` multi-user.target directly — they need each instance enabled.
+
+- `infrastructure/nixos/modules/deploy.nix`
+  - After `systemctl restart` / `systemctl start`, also run `systemctl enable` for the instance so
+    `/etc/systemd/system/multi-user.target.wants/forms-lab-app@<branch>.service` is symlinked, which
+    is what makes the instance come back on reboot.
+  - No branch-teardown path exists in the deploy script today (GitHub-delete only marks the deployment
+    inactive in the GitHub API; nothing on the filesystem is removed). So "symmetric `disable` on teardown"
+    has no site to land in. Noted here so we remember to add `disable` alongside if/when teardown is
+    implemented.
+
+- `infrastructure/nixos/configuration.nix`
+  - The `forms-lab` user needs passwordless sudo for `systemctl enable forms-lab-app@*` and
+    `systemctl disable forms-lab-app@*` in addition to the existing rules.
+
+- `infrastructure/nixos/modules/homepage.nix`, `modules/webhook.nix`, `modules/notify.nix`
+  - Already have `wantedBy = [ "multi-user.target" ]`. Verified, no change.
+
+### Fix 2 — Webhook mid-build recovery + startup scan
+
+- `src/entrypoints/webhook/recovery.ts` (new)
+  - Pure functions, unit-testable:
+    - `listBranchUnitsFromCaddy(caddyDir)`: scan `branch-*.caddy` files, return list of branch unit names.
+    - `computeUnitsToStart(branchUnits, activeUnits)`: given a set of known branch units and a set of
+      currently-active systemd unit names, return the difference.
+    - `isStaleLockfile(mtime, now, maxAgeMs)`: returns true when mtime is older than threshold.
+  - Impure functions (thin shell-exec wrappers) injectable so tests do not call `systemctl`:
+    - `getActiveBranchUnits(exec)`: runs `systemctl list-units 'forms-lab-app@*' --state=active --no-legend`
+      and parses output.
+    - `startInactiveBranchUnits({caddyDir, exec})`: orchestrates the above; returns the list it started.
+
+- `src/entrypoints/webhook/main.ts`
+  - On service startup (after the port is bound), fire-and-forget call to `startInactiveBranchUnits()`
+    and log the result. Failure here should not crash the webhook.
+
+- `infrastructure/nixos/modules/deploy.nix` (shell-side lockfile + idempotency)
+  - Acquire `$BRANCH_DIR/.deploy-in-progress` at the top of the deploy.
+  - If a lockfile exists but is older than 10 minutes, treat it as stale (stale deploy process) and
+    remove it before proceeding.
+  - On `set -e` trap EXIT, remove the lockfile on both success and failure (normal script exit).
+  - If build stopped mid-way, `dist/` may be stale. Simple fix: run `rm -rf dist/` when the stale
+    lockfile was detected (so the subsequent `bun run build` starts clean). On a normal deploy, leave
+    `dist/` alone — `bun run build` handles incremental rebuilds correctly on its own.
+
+- `test/webhook-recovery.test.ts` (new)
+  - Test the pure helpers and the orchestrator with mocked exec.
+
+## Non-goals
+
+- Not implementing branch-teardown on delete (out of scope).
+- Not introducing a queue / persistent deploy state store.
+- Not applying NixOS to the running EC2 manually — merge to main triggers auto-deploy and rebuild.
+  The NixOS config takes effect after the next rebuild (next main push), and the app-enable behavior
+  is only needed after the *next* reboot, so no urgency.
+
+## Commits
+
+1. `infra(nixos): make branch app template reboot-safe` — edit `app.nix` + `deploy.nix` to enable
+   instances after start; update `configuration.nix` sudoers.
+2. `infra(webhook): add startup recovery for inactive branch apps` — new `recovery.ts` + wire into
+   `main.ts` + test.
+3. `infra(nixos): lockfile + stale build recovery in deploy.sh` — lockfile hygiene in `deploy.nix`.
+
+## Testing
+
+- `bun run check` (lint + types + tests; baseline 1230 passing).
+- Pure recovery helpers covered by unit tests with mocked exec.
+- NixOS change is deployed by merging to main; effect is only visible after the next reboot.

--- a/src/entrypoints/webhook/main.ts
+++ b/src/entrypoints/webhook/main.ts
@@ -3,6 +3,7 @@ import { createGitHubClient } from '../../services/deployment/github'
 import { deployMainBranch, triggerDeployWithStatus } from './deploy'
 import type { PushPayload } from './handler'
 import { parseDeleteEvent, parsePushEvent, verifySignature } from './handler'
+import { createSystemctlExec, startInactiveBranchUnits } from './recovery'
 
 const app = new Hono()
 
@@ -132,6 +133,26 @@ async function markDeploymentInactive(
 
 const port = process.env.PORT || 9000
 console.log(`Webhook listener running on port ${port}`)
+
+// Recover any branch apps that should be running but aren't. This catches
+// the reboot case — on boot systemd starts only the instances that were
+// `systemctl enable`-d; anything older than that NixOS change (or
+// transient failures) gets picked up here. Fire-and-forget; never block
+// startup on this.
+const caddyDir = process.env.CADDY_BRANCH_DIR || '/srv/forms-lab/caddy.d'
+startInactiveBranchUnits({ caddyDir, exec: createSystemctlExec() })
+  .then((started) => {
+    if (started.length > 0) {
+      console.log(
+        `Recovery: started ${started.length} inactive branch unit(s): ${started.join(', ')}`,
+      )
+    } else {
+      console.log('Recovery: all known branch units already active')
+    }
+  })
+  .catch((err) => {
+    console.error('Recovery: unexpected error during startup scan:', err)
+  })
 
 export default {
   port: Number(port),

--- a/src/entrypoints/webhook/recovery.ts
+++ b/src/entrypoints/webhook/recovery.ts
@@ -1,0 +1,191 @@
+/**
+ * Recovery for inactive branch apps after a webhook restart (including reboot).
+ *
+ * Motivation: 2026-04-19 incident where a force-stop/start of the EC2 box
+ * left every `forms-lab-app@<branch>.service` instance dead until an operator
+ * manually ran `systemctl start`. The NixOS-side fix (enabling each instance
+ * on deploy) addresses future branches; this module addresses the webhook's
+ * own startup so it can cross-check Caddy routes against active units and
+ * start any that are missing — belt-and-braces for the reboot path.
+ *
+ * Design:
+ * - Pure helpers take strings / arrays, have no I/O, are trivially tested.
+ * - The one I/O orchestrator (`startInactiveBranchUnits`) takes an injectable
+ *   `exec` object so tests never actually call systemctl.
+ */
+
+import { readdir, stat } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const BRANCH_FILE_PATTERN = /^branch-(.+)\.caddy$/
+
+/**
+ * List systemd unit names implied by the branch-*.caddy files in `caddyDir`.
+ * Returns e.g. `['forms-lab-app@main.service', 'forms-lab-app@experiment-74.service']`.
+ * Returns `[]` when the directory is missing or contains no branch files.
+ */
+export async function listBranchUnitsFromCaddy(
+  caddyDir: string,
+): Promise<string[]> {
+  let entries: string[]
+  try {
+    entries = await readdir(caddyDir)
+  } catch {
+    return []
+  }
+
+  const units: string[] = []
+  for (const entry of entries) {
+    const match = entry.match(BRANCH_FILE_PATTERN)
+    if (!match) continue
+    units.push(`forms-lab-app@${match[1]}.service`)
+  }
+  return units
+}
+
+/**
+ * Parse `systemctl list-units 'forms-lab-app@*' --no-legend` output into
+ * a list of unit names. Accepts the plain-whitespace output format.
+ */
+export function parseActiveBranchUnits(output: string): string[] {
+  const units: string[] = []
+  for (const line of output.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    const firstToken = trimmed.split(/\s+/)[0]
+    if (
+      firstToken.startsWith('forms-lab-app@') &&
+      firstToken.endsWith('.service')
+    ) {
+      units.push(firstToken)
+    }
+  }
+  return units
+}
+
+/**
+ * Given the list of branch units known from Caddy and the list of currently
+ * active units from systemd, return the units that need to be started.
+ */
+export function computeUnitsToStart(
+  branchUnits: string[],
+  activeUnits: string[],
+): string[] {
+  const active = new Set(activeUnits)
+  return branchUnits.filter((u) => !active.has(u))
+}
+
+/**
+ * True if the lockfile mtime is strictly older than `maxAgeMs` relative to `now`.
+ * Used to expire stale `.deploy-in-progress` lockfiles left behind by a
+ * crashed deploy run. The boundary case (mtime == now - maxAgeMs) is NOT stale.
+ */
+export function isStaleLockfile(
+  mtimeMs: number,
+  nowMs: number,
+  maxAgeMs: number,
+): boolean {
+  return nowMs - mtimeMs > maxAgeMs
+}
+
+/**
+ * Stat a lockfile and decide whether it is stale. Returns null if the
+ * file does not exist.
+ */
+export async function lockfileMtimeMs(path: string): Promise<number | null> {
+  try {
+    const s = await stat(path)
+    return s.mtimeMs
+  } catch {
+    return null
+  }
+}
+
+/**
+ * I/O-boundary executor. Tests inject a fake; production wires this to
+ * actual systemctl calls.
+ */
+export interface RecoveryExec {
+  /** Runs the equivalent of `systemctl list-units 'forms-lab-app@*' --state=active --no-legend` and returns stdout. */
+  listActive: () => Promise<string>
+  /** Runs the equivalent of `sudo systemctl start <unit>`. Throws on failure. */
+  start: (unit: string) => Promise<void>
+}
+
+export interface StartInactiveOptions {
+  caddyDir: string
+  exec: RecoveryExec
+  logger?: Pick<Console, 'log' | 'warn' | 'error'>
+}
+
+/**
+ * Scan caddy.d for known branches, check which aren't active, start the
+ * missing ones. Returns the list that was successfully started. Never throws.
+ */
+export async function startInactiveBranchUnits(
+  options: StartInactiveOptions,
+): Promise<string[]> {
+  const { caddyDir, exec, logger = console } = options
+
+  const branchUnits = await listBranchUnitsFromCaddy(caddyDir)
+  if (branchUnits.length === 0) return []
+
+  let activeOutput = ''
+  try {
+    activeOutput = await exec.listActive()
+  } catch (err) {
+    logger.warn('Recovery: failed to list active units:', err)
+    return []
+  }
+
+  const activeUnits = parseActiveBranchUnits(activeOutput)
+  const toStart = computeUnitsToStart(branchUnits, activeUnits)
+
+  const started: string[] = []
+  for (const unit of toStart) {
+    try {
+      await exec.start(unit)
+      started.push(unit)
+      logger.log(`Recovery: started ${unit}`)
+    } catch (err) {
+      logger.error(`Recovery: failed to start ${unit}:`, err)
+    }
+  }
+  return started
+}
+
+/**
+ * Default exec implementation that shells out to systemctl. Only used in
+ * production; tests should provide their own.
+ */
+export function createSystemctlExec(): RecoveryExec {
+  return {
+    listActive: async () => {
+      const proc = Bun.spawn(
+        [
+          'systemctl',
+          'list-units',
+          'forms-lab-app@*',
+          '--state=active',
+          '--no-legend',
+          '--no-pager',
+        ],
+        { stdout: 'pipe', stderr: 'pipe' },
+      )
+      const stdout = await new Response(proc.stdout).text()
+      await proc.exited
+      return stdout
+    },
+    start: async (unit: string) => {
+      const proc = Bun.spawn(
+        ['/run/wrappers/bin/sudo', 'systemctl', 'start', unit],
+        { stdout: 'pipe', stderr: 'pipe' },
+      )
+      const stderr = await new Response(proc.stderr).text()
+      const exitCode = await proc.exited
+      if (exitCode !== 0) {
+        throw new Error(`systemctl start ${unit} failed: ${stderr}`)
+      }
+    },
+  }
+}

--- a/test/webhook-recovery.test.ts
+++ b/test/webhook-recovery.test.ts
@@ -1,0 +1,221 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  computeUnitsToStart,
+  isStaleLockfile,
+  listBranchUnitsFromCaddy,
+  parseActiveBranchUnits,
+  startInactiveBranchUnits,
+} from '../src/entrypoints/webhook/recovery'
+
+describe('listBranchUnitsFromCaddy', () => {
+  let caddyDir: string
+
+  beforeEach(async () => {
+    caddyDir = await mkdtemp(join(tmpdir(), 'caddy-test-'))
+  })
+
+  afterEach(async () => {
+    await rm(caddyDir, { recursive: true, force: true })
+  })
+
+  it('returns unit names for each branch-*.caddy file', async () => {
+    await writeFile(join(caddyDir, 'branch-main.caddy'), '# main route')
+    await writeFile(
+      join(caddyDir, 'branch-experiment-74-rag.caddy'),
+      '# exp route',
+    )
+    await writeFile(join(caddyDir, 'root.caddy'), '# root route')
+
+    const units = await listBranchUnitsFromCaddy(caddyDir)
+    expect(units.sort()).toEqual([
+      'forms-lab-app@experiment-74-rag.service',
+      'forms-lab-app@main.service',
+    ])
+  })
+
+  it('returns empty array when no branch files exist', async () => {
+    await writeFile(join(caddyDir, 'root.caddy'), '# root only')
+    const units = await listBranchUnitsFromCaddy(caddyDir)
+    expect(units).toEqual([])
+  })
+
+  it('returns empty array when directory does not exist', async () => {
+    const units = await listBranchUnitsFromCaddy('/nonexistent-caddy-dir-xyz')
+    expect(units).toEqual([])
+  })
+
+  it('ignores files that do not match the branch-*.caddy pattern', async () => {
+    await writeFile(join(caddyDir, 'branch-main.caddy'), '# main')
+    await writeFile(join(caddyDir, 'branch-main.caddy.bak'), '# backup')
+    await writeFile(join(caddyDir, 'other.caddy'), '# other')
+
+    const units = await listBranchUnitsFromCaddy(caddyDir)
+    expect(units).toEqual(['forms-lab-app@main.service'])
+  })
+})
+
+describe('parseActiveBranchUnits', () => {
+  it('extracts unit names from systemctl --no-legend output', () => {
+    const output = [
+      'forms-lab-app@main.service              loaded active running   Forms Lab App - main',
+      'forms-lab-app@experiment-73.service     loaded active running   Forms Lab App - experiment-73',
+    ].join('\n')
+    expect(parseActiveBranchUnits(output).sort()).toEqual([
+      'forms-lab-app@experiment-73.service',
+      'forms-lab-app@main.service',
+    ])
+  })
+
+  it('skips blank lines and non-matching rows', () => {
+    const output = [
+      '',
+      'forms-lab-app@main.service              loaded active running   Forms Lab App - main',
+      '  ',
+      'unrelated.service                       loaded active running   Something else',
+    ].join('\n')
+    expect(parseActiveBranchUnits(output)).toEqual([
+      'forms-lab-app@main.service',
+    ])
+  })
+
+  it('returns empty array for empty input', () => {
+    expect(parseActiveBranchUnits('')).toEqual([])
+  })
+})
+
+describe('computeUnitsToStart', () => {
+  it('returns branch units that are not in the active set', () => {
+    const result = computeUnitsToStart(
+      [
+        'forms-lab-app@main.service',
+        'forms-lab-app@experiment-73.service',
+        'forms-lab-app@experiment-74.service',
+      ],
+      ['forms-lab-app@main.service'],
+    )
+    expect(result.sort()).toEqual([
+      'forms-lab-app@experiment-73.service',
+      'forms-lab-app@experiment-74.service',
+    ])
+  })
+
+  it('returns empty array when all branch units are active', () => {
+    const result = computeUnitsToStart(
+      ['forms-lab-app@main.service'],
+      ['forms-lab-app@main.service'],
+    )
+    expect(result).toEqual([])
+  })
+
+  it('returns empty array when there are no branch units', () => {
+    expect(computeUnitsToStart([], ['forms-lab-app@main.service'])).toEqual([])
+  })
+})
+
+describe('isStaleLockfile', () => {
+  it('returns true when mtime is older than threshold', () => {
+    const now = Date.now()
+    const elevenMinutesAgo = now - 11 * 60 * 1000
+    expect(isStaleLockfile(elevenMinutesAgo, now, 10 * 60 * 1000)).toBe(true)
+  })
+
+  it('returns false when mtime is within threshold', () => {
+    const now = Date.now()
+    const fiveMinutesAgo = now - 5 * 60 * 1000
+    expect(isStaleLockfile(fiveMinutesAgo, now, 10 * 60 * 1000)).toBe(false)
+  })
+
+  it('returns false when mtime is exactly at threshold', () => {
+    const now = Date.now()
+    const exactly = now - 10 * 60 * 1000
+    expect(isStaleLockfile(exactly, now, 10 * 60 * 1000)).toBe(false)
+  })
+})
+
+describe('startInactiveBranchUnits', () => {
+  let caddyDir: string
+
+  beforeEach(async () => {
+    caddyDir = await mkdtemp(join(tmpdir(), 'caddy-recover-'))
+  })
+
+  afterEach(async () => {
+    await rm(caddyDir, { recursive: true, force: true })
+  })
+
+  it('starts units that are not in the active set', async () => {
+    await writeFile(join(caddyDir, 'branch-main.caddy'), '# main')
+    await writeFile(join(caddyDir, 'branch-experiment-74.caddy'), '# exp')
+
+    const startCalls: string[] = []
+    const exec = {
+      listActive: async () =>
+        'forms-lab-app@main.service loaded active running',
+      start: async (unit: string) => {
+        startCalls.push(unit)
+      },
+    }
+
+    const started = await startInactiveBranchUnits({ caddyDir, exec })
+    expect(started).toEqual(['forms-lab-app@experiment-74.service'])
+    expect(startCalls).toEqual(['forms-lab-app@experiment-74.service'])
+  })
+
+  it('starts nothing when all branch units are active', async () => {
+    await writeFile(join(caddyDir, 'branch-main.caddy'), '# main')
+
+    const startCalls: string[] = []
+    const exec = {
+      listActive: async () =>
+        'forms-lab-app@main.service loaded active running',
+      start: async (unit: string) => {
+        startCalls.push(unit)
+      },
+    }
+
+    const started = await startInactiveBranchUnits({ caddyDir, exec })
+    expect(started).toEqual([])
+    expect(startCalls).toEqual([])
+  })
+
+  it('continues when one start fails and reports the survivors', async () => {
+    await writeFile(join(caddyDir, 'branch-a.caddy'), '# a')
+    await writeFile(join(caddyDir, 'branch-b.caddy'), '# b')
+
+    const startCalls: string[] = []
+    const exec = {
+      listActive: async () => '',
+      start: async (unit: string) => {
+        startCalls.push(unit)
+        if (unit === 'forms-lab-app@a.service') {
+          throw new Error('mock failure for a')
+        }
+      },
+    }
+
+    const started = await startInactiveBranchUnits({ caddyDir, exec })
+    // Both were attempted, only b succeeded.
+    expect(startCalls.sort()).toEqual([
+      'forms-lab-app@a.service',
+      'forms-lab-app@b.service',
+    ])
+    expect(started).toEqual(['forms-lab-app@b.service'])
+  })
+
+  it('returns empty list when caddyDir is missing', async () => {
+    const exec = {
+      listActive: async () => '',
+      start: async () => {
+        throw new Error('should not be called')
+      },
+    }
+    const started = await startInactiveBranchUnits({
+      caddyDir: '/nonexistent-xyz',
+      exec,
+    })
+    expect(started).toEqual([])
+  })
+})


### PR DESCRIPTION
## Context

On 2026-04-19 ~15:49 UTC the EC2 instance froze while the webhook was mid-way through `bun run build:components` for `experiment/74-rag-extraction` (commit `f00d5e0`). A force-stop/start preserved the Elastic IP, but surfaced two infrastructure bugs:

1. **Branch app template units did not auto-restart after reboot.** `forms-lab-app@main`, `forms-lab-app@experiment-73-prompt-optimization`, and `forms-lab-app@experiment-75-shaping-eval` all stayed `inactive (dead)` until manually started. Root cause: template units (`forms-lab-app@.service`) cannot be `wantedBy` multi-user.target as a whole — each instance must be `systemctl enable`-d individually so it's symlinked into `multi-user.target.wants/`. The deploy script was only calling `systemctl start`.
2. **Mid-build kills left deploys in a half-state.** Partial `dist/`, no restart, no recovery trigger until the next push arrived.

## Changes

Three commits, one logical change each.

### `infra(nixos): make branch app template reboot-safe`
- `infrastructure/nixos/modules/deploy.nix` — after start/restart, also `systemctl enable` the instance.
- `infrastructure/nixos/modules/app.nix` — add `startLimitBurst = 5` / `startLimitIntervalSec = 300` so a broken branch cannot flap forever.
- `infrastructure/nixos/configuration.nix` — NOPASSWD sudo rules for `systemctl enable/disable forms-lab-app@*`.

### `infra(webhook): add startup recovery for inactive branch apps`
- `src/entrypoints/webhook/recovery.ts` (new) — pure helpers + one injectable-exec orchestrator. Scans `branch-*.caddy` files, diffs against `systemctl list-units 'forms-lab-app@*' --state=active`, starts the gap.
- `src/entrypoints/webhook/main.ts` — fire-and-forget recovery call after port bind; never blocks startup.
- `test/webhook-recovery.test.ts` (new) — 17 tests with mocked exec.

### `infra(nixos): lockfile + stale-build recovery in deploy.sh`
- `infrastructure/nixos/modules/deploy.nix` — `.deploy-in-progress` lockfile per branch. Stale threshold 10 min. On stale detection, wipe partial `dist/` and proceed. Trap removes lockfile on any exit.

## Why two paths?

Belt and braces. The NixOS `enable` change covers branches deployed **after** this merges. The webhook startup scan covers branches that pre-date this change and never receive another push — they still come back on the first webhook-service start after reboot.

## Testing

- 17 new tests for the recovery module (pure helpers + orchestrator with mocked exec).
- `bun run check` green: 1203 passing, 0 failing (baseline 1186 + 17 new).
- No live systemd/EC2 testing — NixOS change takes effect after the next `nixos-rebuild switch`, which the merge triggers.

## Rollout

- Merge to main → webhook auto-deploys → NixOS rebuild applies the new config (sudoers + app.nix limits + deploy script).
- First post-merge push to a branch re-runs deploy and `systemctl enable`s the instance.
- Webhook restarts as part of rebuild, so its recovery scan runs immediately — this should re-`systemctl start` anything currently stale on the running instance without a reboot.
- The reboot-safety behavior kicks in fully on the **next** EC2 reboot.

## Related

- Incident: 2026-04-19 ~15:49 UTC (EC2 freeze mid-build)
- Design notes: `notes/2026-04-19-infra-reboot-safe/design.md`