### PR TITLE
infra(nixos): [Install] section on forms-lab-app template for reboot-safety

### DIFF
--- a/infrastructure/nixos/modules/app.nix
+++ b/infrastructure/nixos/modules/app.nix
@@ -8,6 +8,15 @@
     after = [ "network.target" ];
     onFailure = [ "forms-lab-notify-failure@%n.service" ];
 
+    # wantedBy on a template populates the [Install] section of the
+    # generated unit file. The bare template itself still cannot be
+    # enabled, but each instance — forms-lab-app@<branch>.service — now
+    # has a [Install] section that `systemctl enable` can act on, which
+    # symlinks it into multi-user.target.wants/ so it restarts on
+    # reboot. Without this, `enable` is a no-op ("static") and branch
+    # apps stay dead after a reboot.
+    wantedBy = [ "multi-user.target" ];
+
     path = [ pkgs.git ];
 
     serviceConfig = {


### PR DESCRIPTION
## Context

Follow-up to #79. That PR added `systemctl enable forms-lab-app@<branch>` to the deploy script, intending to make branch apps survive reboots. But the template unit had no `[Install]` section, so `enable` silently produced no symlink — `systemctl is-enabled` returned `static` for every instance, and the reboot-safety half of #79 was effectively a no-op.

The webhook startup recovery path (also landed in #79) still works as a fallback, which is why the live instance currently has all branch apps active. But one-step reboot recovery — the intent — wasn't actually working.

## Changes

`infrastructure/nixos/modules/app.nix`: add `wantedBy = [ "multi-user.target" ]` on the `forms-lab-app@` template. NixOS translates this into a real `[Install]` section in the generated unit file. The bare template still can't be enabled, but each instance now carries the `[Install]` section, so `systemctl enable forms-lab-app@<branch>` (which the deploy script already runs) symlinks the instance into `multi-user.target.wants/` and the branch app auto-starts on boot.

Comments in `configuration.nix` and `deploy.nix` about "template units cannot be wantedBy multi-user.target as a whole" remain accurate — they describe the bare-template constraint, not the per-instance `[Install]` behavior.

## Testing

- [x] `bun run check` — 1203/0 tests
- [x] Webhook startup recovery tests still pass (they're orthogonal)
- [ ] Next reboot of the EC2 box: all currently-enabled branch apps should auto-start (not verified here — PR merge triggers a NixOS rebuild that re-enables them symmetrically)

## Verification after merge

After `nixos-rebuild switch` lands, run on the box:
```
systemctl is-enabled forms-lab-app@main forms-lab-app@experiment-73-prompt-optimization
```
Expected: `enabled` (not `static`). The deploy script's `systemctl enable` call, which was a no-op before, will now produce a real symlink on the next deploy of each branch. Existing branches can be re-enabled in-place with `for u in $(systemctl list-units forms-lab-app@*.service --no-legend | awk '{print $1}'); do sudo systemctl enable \$u; done` if you want immediate reboot-safety without waiting for each branch to redeploy.

## Related

- Follow-up to #79
- Closes the reboot-safety gap noted in the #79 post-merge triage