### PR TITLE
infra: pulumi t3.medium, systemd-generator reboot-safety, branch-delete teardown

### DIFF
--- a/infrastructure/nixos/configuration.nix
+++ b/infrastructure/nixos/configuration.nix
@@ -86,15 +86,6 @@
       command = "${pkgs.systemd}/bin/systemctl stop forms-lab-app@*";
       options = [ "NOPASSWD" ];
     } {
-      # Enable/disable per-instance template units so they survive reboots.
-      # Template units cannot be wantedBy multi-user.target as a whole —
-      # each instance must be individually symlinked.
-      command = "${pkgs.systemd}/bin/systemctl enable forms-lab-app@*";
-      options = [ "NOPASSWD" ];
-    } {
-      command = "${pkgs.systemd}/bin/systemctl disable forms-lab-app@*";
-      options = [ "NOPASSWD" ];
-    } {
       command = "${pkgs.systemd}/bin/systemctl restart forms-lab-homepage.service";
       options = [ "NOPASSWD" ];
     } {

--- a/infrastructure/nixos/modules/app.nix
+++ b/infrastructure/nixos/modules/app.nix
@@ -1,6 +1,59 @@
 { config, pkgs, ... }:
 
+let
+  # Systemd generator: at boot time, before multi-user.target resolves,
+  # look at /srv/forms-lab/caddy.d/branch-*.caddy and for each branch
+  # write a symlink in /run/systemd/system/multi-user.target.wants/ that
+  # points at the branch's template instance. This is how you give a
+  # dynamic set of template instances an [Install] relationship on
+  # NixOS — you can't write to /etc/systemd/system/multi-user.target.wants/
+  # (read-only, NixOS-managed) and `systemctl enable` on a template
+  # instance fails because the instance unit file doesn't exist.
+  #
+  # /run is tmpfs and writable, so this runs cleanly on every boot.
+  branchAppGenerator = pkgs.writeShellScript "forms-lab-branch-app-generator" ''
+    set -euo pipefail
+
+    # systemd passes three target directories; we want the second
+    # ("early" per `man systemd.generator` — generators may place
+    # generated units there, which systemd treats as equivalent to
+    # /etc/systemd/system).
+    EARLY_DIR="''${2:-}"
+    [ -z "$EARLY_DIR" ] && exit 0
+
+    CADDY_DIR=/srv/forms-lab/caddy.d
+    [ -d "$CADDY_DIR" ] || exit 0
+
+    WANTS_DIR="$EARLY_DIR/multi-user.target.wants"
+    mkdir -p "$WANTS_DIR"
+
+    # Unit file lives in the nix store; the bare template unit is the
+    # target for every per-branch instance symlink.
+    TEMPLATE_UNIT=/etc/systemd/system/forms-lab-app@.service
+
+    for caddy_file in "$CADDY_DIR"/branch-*.caddy; do
+      [ -f "$caddy_file" ] || continue
+      base=$(${pkgs.coreutils}/bin/basename "$caddy_file" .caddy)
+      branch=''${base#branch-}
+      [ -z "$branch" ] && continue
+
+      # Systemd interprets a symlink named foo@bar.service inside a
+      # .wants/ directory as "want instance bar of template foo@.service".
+      ${pkgs.coreutils}/bin/ln -sf "$TEMPLATE_UNIT" "$WANTS_DIR/forms-lab-app@$branch.service"
+    done
+  '';
+in
 {
+  # Install the generator at /etc/systemd/system-generators/, which
+  # systemd reads on every boot before unit resolution. NixOS has no
+  # dedicated option for generators, but environment.etc works — systemd
+  # consults /etc/systemd/system-generators/ in addition to the
+  # package-provided /lib/systemd/system-generators/ directory.
+  environment.etc."systemd/system-generators/forms-lab-branch-apps" = {
+    source = branchAppGenerator;
+    mode = "0755";
+  };
+
   # Template unit for branch app services
   # Instantiated by the deploy script as forms-lab-app@<branch>.service
   systemd.services."forms-lab-app@" = {
@@ -8,14 +61,12 @@
     after = [ "network.target" ];
     onFailure = [ "forms-lab-notify-failure@%n.service" ];
 
-    # wantedBy on a template populates the [Install] section of the
-    # generated unit file. The bare template itself still cannot be
-    # enabled, but each instance — forms-lab-app@<branch>.service — now
-    # has a [Install] section that `systemctl enable` can act on, which
-    # symlinks it into multi-user.target.wants/ so it restarts on
-    # reboot. Without this, `enable` is a no-op ("static") and branch
-    # apps stay dead after a reboot.
-    wantedBy = [ "multi-user.target" ];
+    # Note: we intentionally do NOT set `wantedBy = [ "multi-user.target" ]`
+    # on this bare template. NixOS would interpret that as creating a
+    # useless `forms-lab-app@multi-user.service` instance on every
+    # rebuild. Reboot-safety is instead provided by the generator above:
+    # it reads /srv/forms-lab/caddy.d/branch-*.caddy at boot and wants
+    # each instance that has a Caddy route.
 
     path = [ pkgs.git ];
 

--- a/infrastructure/nixos/modules/deploy.nix
+++ b/infrastructure/nixos/modules/deploy.nix
@@ -194,13 +194,12 @@ ENVEOF
     /run/wrappers/bin/sudo ${pkgs.systemd}/bin/systemctl restart "forms-lab-app@$UNIT_NAME.service" || \
       /run/wrappers/bin/sudo ${pkgs.systemd}/bin/systemctl start "forms-lab-app@$UNIT_NAME.service"
 
-    # Enable the instance so it survives reboots. Template units are not
-    # wantedBy multi-user.target on their own — each instance must be
-    # individually symlinked into multi-user.target.wants/. Without this,
-    # a reboot leaves branch apps dead until something explicitly starts
-    # them (which the webhook's startup recovery also handles as a
-    # belt-and-braces fallback).
-    /run/wrappers/bin/sudo ${pkgs.systemd}/bin/systemctl enable "forms-lab-app@$UNIT_NAME.service" || true
+    # Reboot-safety: the forms-lab-branch-apps systemd generator reads
+    # $DEPLOY_ROOT/caddy.d/ at boot time and wires every branch with a
+    # Caddy route into multi-user.target. We write the Caddy file below,
+    # so this branch is automatically "enabled" for the next reboot —
+    # no systemctl enable needed (which wouldn't work for template
+    # instances on NixOS anyway).
 
     # Write Caddy route snippet to persistent config directory
     CADDY_DIR="$DEPLOY_ROOT/caddy.d"
@@ -242,13 +241,68 @@ CADDYEOF
       echo "Homepage service restarted"
     fi
   '';
+
+  # Branch teardown: stop + disable the app, remove the Caddy route and
+  # worktree, free the port. Called by the webhook on a GitHub `delete`
+  # event, and by the CLI for manual cleanup. Refuses to tear down
+  # protected branches (main) as a safety rail.
+  teardownScript = pkgs.writeShellScriptBin "forms-lab-teardown" ''
+    set -euo pipefail
+
+    BRANCH="$1"
+    DEPLOY_ROOT="/srv/forms-lab"
+    SAFE_BRANCH=$(echo "$BRANCH" | ${pkgs.coreutils}/bin/tr '/' '-')
+
+    if [ "$SAFE_BRANCH" = "main" ] || [ -z "$SAFE_BRANCH" ]; then
+      echo "ERROR: refusing to tear down protected/empty branch '$BRANCH'"
+      exit 1
+    fi
+
+    BRANCH_DIR="$DEPLOY_ROOT/$SAFE_BRANCH"
+    REPO_DIR="$DEPLOY_ROOT/repo.git"
+    PORT_FILE="$DEPLOY_ROOT/ports.json"
+    CADDY_FILE="$DEPLOY_ROOT/caddy.d/branch-$SAFE_BRANCH.caddy"
+    UNIT="forms-lab-app@$SAFE_BRANCH.service"
+
+    echo "Tearing down $BRANCH..."
+
+    # 1. Stop the app (ignore-not-running)
+    /run/wrappers/bin/sudo ${pkgs.systemd}/bin/systemctl stop "$UNIT" || true
+
+    # 2. Remove the Caddy route (this also "disables" the branch for
+    #    reboot-safety because the forms-lab-branch-apps generator
+    #    only wires branches that have a Caddy file).
+    if [ -f "$CADDY_FILE" ]; then
+      ${pkgs.coreutils}/bin/rm -f "$CADDY_FILE"
+      /run/wrappers/bin/sudo ${pkgs.systemd}/bin/systemctl reload caddy.service || true
+    fi
+
+    # 3. Remove the worktree (git-aware so the bare repo stays consistent)
+    if [ -d "$BRANCH_DIR" ]; then
+      if [ -d "$REPO_DIR" ]; then
+        ${pkgs.git}/bin/git -C "$REPO_DIR" worktree remove --force "$BRANCH_DIR" 2>/dev/null || \
+          ${pkgs.coreutils}/bin/rm -rf "$BRANCH_DIR"
+      else
+        ${pkgs.coreutils}/bin/rm -rf "$BRANCH_DIR"
+      fi
+    fi
+
+    # 4. Free the port so the next deploy of this branch gets a fresh one
+    if [ -f "$PORT_FILE" ]; then
+      ${pkgs.jq}/bin/jq "del(.[\"$BRANCH\"])" "$PORT_FILE" > "$PORT_FILE.tmp"
+      mv "$PORT_FILE.tmp" "$PORT_FILE"
+    fi
+
+    echo "Teardown complete for $BRANCH"
+  '';
 in
 {
-  environment.systemPackages = [ deployScript deployMainScript ];
+  environment.systemPackages = [ deployScript deployMainScript teardownScript ];
 
   # Make the deploy scripts available at expected paths
   system.activationScripts.deployLink = ''
     ln -sf ${deployScript}/bin/forms-lab-deploy /srv/forms-lab/deploy.sh
     ln -sf ${deployMainScript}/bin/forms-lab-deploy-main /srv/forms-lab/deploy-main.sh
+    ln -sf ${teardownScript}/bin/forms-lab-teardown /srv/forms-lab/teardown.sh
   '';
 }

--- a/infrastructure/pulumi/index.ts
+++ b/infrastructure/pulumi/index.ts
@@ -103,7 +103,10 @@ const instanceProfile = new aws.iam.InstanceProfile('forms-lab-profile', {
 // EC2 instance
 const instance = new aws.ec2.Instance('forms-lab', {
   ami: nixosAmi.then((ami) => ami.id),
-  instanceType: 't3.small',
+  // Upgraded 2026-04-19: t3.small's 2 GB RAM OOM'd under ~48 branch
+  // app processes during the tier-2 experiment push. t3.medium (4 GB)
+  // accommodates the peak load. See project memory for the incident.
+  instanceType: 't3.medium',
   keyName: keyPair.keyName,
   vpcSecurityGroupIds: [sg.id],
   iamInstanceProfile: instanceProfile.name,

--- a/src/entrypoints/webhook/deploy.ts
+++ b/src/entrypoints/webhook/deploy.ts
@@ -8,6 +8,43 @@ export interface DeployResult {
   stderr?: string
 }
 
+/**
+ * Tear down a branch on the EC2 box: stop + disable the app unit,
+ * remove the Caddy route, delete the worktree, and free the port slot.
+ * Called when GitHub reports a branch deletion.
+ *
+ * Invokes /srv/forms-lab/teardown.sh, which is installed by the NixOS
+ * deploy module. Path is overridable for tests.
+ */
+export async function teardownBranch(branch: string): Promise<DeployResult> {
+  const script = process.env.TEARDOWN_SCRIPT || '/srv/forms-lab/teardown.sh'
+
+  try {
+    const proc = Bun.spawn([script, branch], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+
+    const [stdout, stderr] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ])
+    const exitCode = await proc.exited
+
+    if (exitCode !== 0) {
+      console.error(`Teardown failed for ${branch}:`, stderr)
+      return { success: false, error: stderr, stdout, stderr }
+    }
+
+    console.log(`Teardown succeeded for ${branch}`)
+    return { success: true, stdout, stderr }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    console.error(`Teardown error for ${branch}:`, message)
+    return { success: false, error: message }
+  }
+}
+
 export async function triggerDeploy(
   branch: string,
   sha: string,

--- a/src/entrypoints/webhook/main.ts
+++ b/src/entrypoints/webhook/main.ts
@@ -1,6 +1,10 @@
 import { Hono } from 'hono'
 import { createGitHubClient } from '../../services/deployment/github'
-import { deployMainBranch, triggerDeployWithStatus } from './deploy'
+import {
+  deployMainBranch,
+  teardownBranch,
+  triggerDeployWithStatus,
+} from './deploy'
 import type { PushPayload } from './handler'
 import { parseDeleteEvent, parsePushEvent, verifySignature } from './handler'
 import { createSystemctlExec, startInactiveBranchUnits } from './recovery'
@@ -52,6 +56,22 @@ app.post('/', async (c) => {
   // Handle branch deletion
   const deletion = parseDeleteEvent(payload)
   if (deletion) {
+    // Refuse to tear down protected branches even if GitHub reports a
+    // deletion for them — defence in depth; the teardown script itself
+    // already guards against this.
+    if (deletion.branch === 'main') {
+      return c.json(
+        { ignored: true, reason: 'Refusing to tear down main' },
+        200,
+      )
+    }
+
+    // Tear down the filesystem + systemd state on the box. Fire-and-forget:
+    // webhook responds 202 immediately, the box settles asynchronously.
+    teardownBranch(deletion.branch).catch((err) => {
+      console.error(`Teardown failed for ${deletion.branch}:`, err)
+    })
+
     if (githubClient && deletion.owner && deletion.repo) {
       markDeploymentInactive(
         deletion.owner,

--- a/test/webhook-deploy.test.ts
+++ b/test/webhook-deploy.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import {
   deployMainBranch,
+  teardownBranch,
   triggerDeploy,
   triggerDeployWithStatus,
 } from '../src/entrypoints/webhook/deploy'
@@ -93,6 +94,48 @@ describe('triggerDeploy', () => {
     expect(typeof result.error === 'string' || result.error === undefined).toBe(
       true,
     )
+  })
+})
+
+describe('teardownBranch', () => {
+  beforeEach(() => {
+    process.env.TEARDOWN_SCRIPT = 'echo'
+  })
+
+  afterEach(() => {
+    delete process.env.TEARDOWN_SCRIPT
+  })
+
+  it('returns success when script exits with code 0', async () => {
+    const result = await teardownBranch('feature/x')
+
+    expect(result.success).toBe(true)
+    expect(result.error).toBeUndefined()
+  })
+
+  it('passes the branch name as an argument to the teardown script', async () => {
+    const result = await teardownBranch('experiment/done')
+
+    expect(result.success).toBe(true)
+    expect(result.stdout?.includes('experiment/done')).toBe(true)
+  })
+
+  it('returns failure when script exits non-zero', async () => {
+    process.env.TEARDOWN_SCRIPT = 'false'
+
+    const result = await teardownBranch('feature/x')
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBeDefined()
+  })
+
+  it('returns error when script is missing', async () => {
+    process.env.TEARDOWN_SCRIPT = '/nonexistent/teardown-script-xyz'
+
+    const result = await teardownBranch('feature/x')
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBeDefined()
   })
 })
 


### PR DESCRIPTION
## Context

Three deploy-infra followups the last incident surfaced.

### 1. Pulumi instance type was stale
After the 2026-04-19 OOM, the live instance was resized `t3.small → t3.medium` via the EC2 API while stopped. Pulumi config still said `t3.small`. Next `pulumi up` would have attempted a downgrade and interrupted the live box.

### 2. #80's `[Install]` fix didn't actually work on NixOS
`wantedBy = [ "multi-user.target" ]` on the bare `forms-lab-app@` template had two problems:
- NixOS created a bogus `forms-lab-app@multi-user.service` instance on every rebuild.
- `systemctl enable forms-lab-app@<branch>` still failed at runtime because the instance unit file doesn't exist standalone and `/etc/systemd/system/multi-user.target.wants/` is read-only on NixOS.

Reboot-safety was load-bearing on the webhook startup recovery pass from #79, not actually on the `[Install]` work.

### 3. No filesystem cleanup on branch delete
Stale `branch-*.caddy` files and worktrees accumulated over weeks (~48 at incident time). The #79 recovery pass happily woke all of them, OOMing the 2 GB box.

## Changes

### `infrastructure/pulumi/index.ts`
- `instanceType: 't3.small' → 't3.medium'` with a comment explaining why.

### `infrastructure/nixos/modules/app.nix`
- Drop the broken `wantedBy` on the template.
- Add a **systemd generator** at `/etc/systemd/system-generators/forms-lab-branch-apps`. Generators run on every boot before unit resolution and may write to `/run` (tmpfs, writable). The generator reads `/srv/forms-lab/caddy.d/branch-*.caddy` and wires each branch into `multi-user.target.wants/`. Reboot-safety is now real and automatic.

### `infrastructure/nixos/modules/deploy.nix`
- Remove the now-useless `systemctl enable` call from the deploy script (also updated the comment that explained why it was "needed").
- Add a `forms-lab-teardown` shell script installed at `/srv/forms-lab/teardown.sh`. It stops the app, removes the Caddy route (which automatically de-wires reboot-safety via the generator), removes the worktree, and frees the port. Refuses to tear down `main` as a safety rail.

### `infrastructure/nixos/configuration.nix`
- Remove the sudoers rules for `systemctl enable/disable forms-lab-app@*` — no longer needed.

### `src/entrypoints/webhook/{deploy,main}.ts`
- New `teardownBranch(branch)` helper that invokes the teardown script.
- Wire it into the existing delete-event handler, in addition to the GitHub deployment-status update that was already happening.
- Defence-in-depth: refuse to tear down `main` at the webhook handler too, not just in the shell script.

### `test/webhook-deploy.test.ts`
- 4 new tests covering `teardownBranch`: success, failure, argument passing, missing-script.

## Test plan

- [x] `bun run check` — 1207 pass / 0 fail (baseline 1203 + 4 new teardown tests)
- [x] Pulumi config verified against live instance state
- [ ] After merge: on next reboot, all branches with Caddy routes auto-start (not verified pre-merge; generator runs at boot only)
- [ ] After merge: delete a throwaway branch on GitHub, verify the worktree/Caddy/systemd state cleans up within ~30 s

## Verification after merge

1. Watch the webhook deploy the new main: `journalctl -u forms-lab-webhook -f`
2. `systemctl cat forms-lab-app@main.service` — should no longer contain `[Install]` (we removed `wantedBy`)
3. `ls /etc/systemd/system-generators/forms-lab-branch-apps` — should be a symlink into the nix store
4. Delete a branch on GitHub, watch `journalctl -u forms-lab-webhook -f` — should see "Tearing down <branch>...". Then `systemctl status forms-lab-app@<branch>` → `not-found`, `ls /srv/forms-lab/caddy.d/branch-<branch>.caddy` → no such file.
5. Trigger a reboot (force-stop + start via `aws ec2`) and watch the box come back with exactly the branches that have Caddy routes.

## Related

- Follow-up to #79 and #80
- Closes the three gaps identified in the post-incident triage