### PR TITLE
fix(nixos): install systemd generator via systemd.packages

### DIFF
--- a/infrastructure/nixos/modules/app.nix
+++ b/infrastructure/nixos/modules/app.nix
@@ -44,15 +44,17 @@ let
   '';
 in
 {
-  # Install the generator at /etc/systemd/system-generators/, which
-  # systemd reads on every boot before unit resolution. NixOS has no
-  # dedicated option for generators, but environment.etc works — systemd
-  # consults /etc/systemd/system-generators/ in addition to the
-  # package-provided /lib/systemd/system-generators/ directory.
-  environment.etc."systemd/system-generators/forms-lab-branch-apps" = {
-    source = branchAppGenerator;
-    mode = "0755";
-  };
+  # Install the generator by bundling it in a systemd.packages entry.
+  # systemd.packages adds a derivation's lib/systemd/ tree to the unit
+  # search path, including its system-generators/ subdir. We can't use
+  # environment.etc because /etc/systemd/system-generators/ collides
+  # with NixOS's stock systemd setup (read-only path conflict).
+  systemd.packages = [
+    (pkgs.runCommand "forms-lab-branch-apps-generator" { } ''
+      install -D -m 0755 ${branchAppGenerator} \
+        $out/lib/systemd/system-generators/forms-lab-branch-apps
+    '')
+  ];
 
   # Template unit for branch app services
   # Instantiated by the deploy script as forms-lab-app@<branch>.service


### PR DESCRIPTION
## Context

Hotfix for #81. The `environment.etc."systemd/system-generators/forms-lab-branch-apps"` approach failed on rebuild with:

```
ln: failed to create symbolic link '/nix/store/.../etc/systemd/system-generators/forms-lab-branch-apps': Permission denied
```

NixOS's stock systemd setup already owns `/etc/systemd/system-generators/` as a read-only directory, so adding another file via `environment.etc` caused a build-time collision.

## Fix

Install the generator the canonical NixOS way: wrap it in a tiny `runCommand` derivation that lays down the file at `$out/lib/systemd/system-generators/forms-lab-branch-apps`, then add the derivation to `systemd.packages`. NixOS merges `lib/systemd/system-generators/` from every packages entry into the effective generator search path.

## Test plan

- [x] `bun run check` — 1207/0
- [ ] Merge triggers the webhook deploy that failed before; verify it succeeds and the generator lands at `/run/current-system/sw/lib/systemd/system-generators/forms-lab-branch-apps`.