### PR TITLE
infra(nixos): fix homepage EADDRINUSE crash loop after story-71 merge

### DIFF
--- a/infrastructure/nixos/modules/app.nix
+++ b/infrastructure/nixos/modules/app.nix
@@ -87,8 +87,14 @@ in
       # systemd interprets these at the [Unit]/[Service] level — NixOS
       # exposes them via startLimit* keys on the service attrset.
 
-      # Environment loaded from a per-branch env file written by deploy script
-      EnvironmentFile = "/srv/forms-lab/%i/.env";
+      # Environment loaded from per-branch files written by deploy script.
+      # .env holds branch-app config (PORT, BASE_PATH, secrets, AWS); the
+      # dedicated .build-info file holds BUILD_GIT_SHA only so the homepage
+      # service can inherit BUILD_GIT_SHA without picking up branch-app PORT.
+      EnvironmentFile = [
+        "/srv/forms-lab/%i/.env"
+        "-/srv/forms-lab/%i/.build-info"
+      ];
     };
 
     # Flap control — prevents a broken branch from retrying forever.

--- a/infrastructure/nixos/modules/deploy.nix
+++ b/infrastructure/nixos/modules/deploy.nix
@@ -175,7 +175,13 @@ let
 
     # Capture the commit SHA of the deployed worktree so getBuildInfo()
     # can resolve the running commit without shelling out to git at runtime.
+    # Written to a dedicated .build-info file (not the branch-app .env)
+    # because the homepage service also needs BUILD_GIT_SHA but must NOT
+    # inherit the branch-app's PORT or BASE_PATH.
     BUILD_GIT_SHA=$(${pkgs.git}/bin/git -C "$BRANCH_DIR" rev-parse HEAD)
+    cat > "$BRANCH_DIR/.build-info" <<BUILDEOF
+BUILD_GIT_SHA=$BUILD_GIT_SHA
+BUILDEOF
 
     # Write per-branch env file
     # All branches serve at /<branch>/
@@ -183,7 +189,6 @@ let
     cat > "$BRANCH_DIR/.env" <<ENVEOF
 PORT=$PORT
 BASE_PATH=/$UNIT_NAME/
-BUILD_GIT_SHA=$BUILD_GIT_SHA
 GITHUB_CLIENT_ID=$(cat /run/secrets/github-client-id 2>/dev/null || echo "")
 GITHUB_CLIENT_SECRET=$(cat /run/secrets/github-client-secret 2>/dev/null || echo "")
 SESSION_SECRET=$(cat /run/secrets/session-secret 2>/dev/null || echo "")

--- a/infrastructure/nixos/modules/homepage.nix
+++ b/infrastructure/nixos/modules/homepage.nix
@@ -20,10 +20,11 @@
       Environment = [
         "PORT=3000"
       ];
-      # Main's .env provides BUILD_GIT_SHA (and future runtime config).
-      # The leading '-' tolerates the file being absent on first boot,
-      # before the first main deployment has run.
-      EnvironmentFile = "-/srv/forms-lab/main/.env";
+      # Load ONLY .build-info (BUILD_GIT_SHA), not .env — the branch-app's
+      # .env sets PORT=<branch-port>, which would override the homepage's
+      # PORT=3000 and cause EADDRINUSE when the dashboard tries to bind.
+      # The leading '-' tolerates the file being absent on first boot.
+      EnvironmentFile = "-/srv/forms-lab/main/.build-info";
       ExecStart = "${config.flexion.entrypointWrapper}/bin/forms-lab-entrypoint dashboard /srv/forms-lab/main";
     };
   };


### PR DESCRIPTION
## Context

Story 71 (#84) added \`EnvironmentFile=-/srv/forms-lab/main/.env\` to the homepage service so \`getBuildInfo()\` could read \`BUILD_GIT_SHA\` at runtime. That file is the per-branch env file the deploy script writes, which sets \`PORT=<branch-port>\` (for main: \`PORT=3001\`). Loading it into the homepage unit overrode the explicit \`Environment=PORT=3000\`, and the dashboard tried to listen on 3001 — already owned by \`forms-lab-app@main\`. Result: \`EADDRINUSE\` and a systemd restart loop (counter hit 17 before I intervened).

## Changes

- \`deploy.nix\`: \`BUILD_GIT_SHA\` now written to a dedicated per-branch \`.build-info\` file (single line) instead of being mixed into \`.env\`. Keeps \`.env\` scoped to branch-app config (PORT, BASE_PATH, secrets).
- \`app.nix\`: branch-app units now load both \`.env\` and (tolerated-missing) \`.build-info\`. They keep seeing \`BUILD_GIT_SHA\` with no change in behaviour.
- \`homepage.nix\`: loads ONLY \`.build-info\` (not \`.env\`). The explicit \`Environment=PORT=3000\` is no longer overridden.

## Emergency fix already applied

To stop the crash loop while this PR lands, I applied a writable \`/run/systemd/system/forms-lab-homepage.service.d/override.conf\` on the box that clears the offending \`EnvironmentFile=\`. Homepage is back up on port 3000 as of the time this PR was opened. The override is harmless after this merges; it'll be replaced on the next \`nixos-rebuild switch\`.

## Testing

- \`bun run check\` passes (1269 tests).
- NixOS syntax visually verified (no \`nix-instantiate\` errors to expect — pure config).
- Post-merge validation:
  - [ ] Webhook deploys main, \`/srv/forms-lab/main/.build-info\` contains \`BUILD_GIT_SHA=<sha>\`.
  - [ ] \`/srv/forms-lab/main/.env\` no longer contains \`BUILD_GIT_SHA\`.
  - [ ] \`systemctl show forms-lab-homepage -p EnvironmentFiles\` shows \`.build-info\` only.
  - [ ] \`ss -tlnp | grep 3000\` shows homepage bun, \`grep 3001\` shows branch-app bun.
  - [ ] Homepage responds 200 at \`/\`.
  - [ ] Branch app at \`/main/\` also 200, and dashboard UI shows the correct commit SHA.