### PR TITLE
docs(catalog): mark tier-2 work shipped, retire #64, reconcile flight board

### DIFF
--- a/catalog/experiments/_roadmap.md
+++ b/catalog/experiments/_roadmap.md
@@ -17,14 +17,14 @@ This is the live roadmap for the Forms Lab LLM experiments. Each experiment is a
 
 | Story | Status | Ships |
 |---|---|---|
-| [#10 Maya chooses how her form was extracted](/catalog/stories) | in-progress ([PR #58](https://github.com/flexion/forms-lab/pull/58)) | variant picker, preferences service, provenance convention, `<VariantBadge>`, expanded fixtures (I-9, W-9), registry-driven extraction |
+| [#10 Maya chooses how her form was extracted](/catalog/stories) | shipped ([PR #58](https://github.com/flexion/forms-lab/pull/58)) | variant picker, preferences service, provenance convention, `<VariantBadge>`, expanded fixtures (I-9, W-9), registry-driven extraction |
 
 ## Picker tabs — parallel after #10 merges
 
 | Story | Status | Ships | Catalog |
 |---|---|---|---|
 | [#59 Maya chooses her shaping model](https://github.com/flexion/forms-lab/issues/59) | shipped | shaping eval-kind, `shaping/haiku`, `shaping/sonnet`, `shaping/opus`, shaping tab in picker | `/catalog/experiments/shaping-model-comparison/` (new suite). Scoring kind is deterministic (command-kind precision/recall + arg accuracy). Live metrics landed via [#75](https://github.com/flexion/forms-lab/issues/75): opus 73/83/67%, sonnet 67/75/62%, haiku 67/83/62%. Model size is not the dominant lever for this suite. |
-| [#75 Run live shaping model evaluation](https://github.com/flexion/forms-lab/issues/75) | pr-open | `evaluate shaping <variant-id>` CLI subcommand, live metrics on all three shaping variants | `/catalog/experiments/shaping-model-comparison/{haiku,sonnet,opus}.md` populated. Finding: three of six intents are at ceiling across all models; two fail across all models — the bottleneck is prompt disambiguation (renamePage vs renameGroup, quoted group-name resolution), not model size. |
+| [#75 Run live shaping model evaluation](https://github.com/flexion/forms-lab/issues/75) | shipped ([PR #77](https://github.com/flexion/forms-lab/pull/77)) | `evaluate shaping <variant-id>` CLI subcommand, live metrics on all three shaping variants | `/catalog/experiments/shaping-model-comparison/{haiku,sonnet,opus}.md` populated. Finding: three of six intents are at ceiling across all models; two fail across all models — the bottleneck is prompt disambiguation (renamePage vs renameGroup, quoted group-name resolution), not model size. |
 | [#60 Carlos's conversation uses a chosen model](https://github.com/flexion/forms-lab/issues/60) | planned | filling eval-kind (personas + scripts), `filling/haiku`, `filling/sonnet`, `filling/opus`, filling tab in picker | `/catalog/experiments/filling-model-comparison/` (new suite) |
 | [#61 Maya verifies AcroForm mapping](https://github.com/flexion/forms-lab/issues/61) | planned | field-mapping eval-kind, `field-mapping/haiku`, `field-mapping/sonnet`, `field-mapping/opus`, mapping tab in picker | `/catalog/experiments/field-mapping/` (new suite) |
 
@@ -32,20 +32,20 @@ This is the live roadmap for the Forms Lab LLM experiments. Each experiment is a
 
 | Story | Status | Ships | Catalog |
 |---|---|---|---|
-| [#62 / #74 Maya's extractions cite the law](https://github.com/flexion/forms-lab/issues/74) | pr-open ([PR #78](https://github.com/flexion/forms-lab/pull/78)) | RAG primitive (embeddings + cosine store), policy corpus, `extraction/sonnet-with-rag` | `/catalog/experiments/pdf-field-extraction/sonnet-with-rag.md`. Finding: sensitivity accuracy +25.3pp, precision +13.6pp, recall -5.7pp. Grounding in CFR/USC text is the largest sensitivity win we've measured outside of tool-use. |
+| [#62 / #74 Maya's extractions cite the law](https://github.com/flexion/forms-lab/issues/74) | shipped ([PR #78](https://github.com/flexion/forms-lab/pull/78)) | RAG primitive (embeddings + cosine store), policy corpus, `extraction/sonnet-with-rag` | `/catalog/experiments/pdf-field-extraction/sonnet-with-rag.md`. Finding: sensitivity accuracy +25.3pp, precision +13.6pp, recall -5.7pp. Grounding in CFR/USC text is the largest sensitivity win we've measured outside of tool-use. |
 | [#63 Maya's extractions learn from curated examples](https://github.com/flexion/forms-lab/issues/63) | shipped | `extraction/few-shot-sonnet`, `extraction/nova-pro` | `/catalog/experiments/pdf-field-extraction/few-shot-sonnet.md`. Finding: precision +7.6pp over baseline; recall -6.8pp. Few-shot helps model be selective, not comprehensive. Nova Pro (non-Claude) fails at field-level extraction entirely. |
-| [#64 Maya's extractions use a tuned prompt](https://github.com/flexion/forms-lab/issues/64) | planned | prompt-opt harness, `extraction/sonnet-optimized-v1` | `/catalog/experiments/pdf-field-extraction/sonnet-optimized-v1.md` |
-| [#73 Maya's extractions use temperature + hybrid prompt](https://github.com/flexion/forms-lab/issues/73) | pr-open ([PR #76](https://github.com/flexion/forms-lab/pull/76)) | `extraction/sonnet-temperature-zero`, `extraction/sonnet-hybrid-v1` | `/catalog/experiments/pdf-field-extraction/sonnet-temperature-zero.md`, `/catalog/experiments/pdf-field-extraction/sonnet-hybrid-v1.md`. Finding: hybrid-v1 wins the suite (precision 99.2%, recall 72.6%, sensitivity +23.8pp over baseline). Temp=0 alone is the largest precision lever (+15.1pp) but costs recall. Assignment 10's prompt-shape rank ordering (hybrid > few-shot > verbose) reproduces on Sonnet. |
+| [#64 Maya's extractions use a tuned prompt](https://github.com/flexion/forms-lab/issues/64) | scope-deferred | — | Superseded by [#73](https://github.com/flexion/forms-lab/issues/73). The hybrid-v1 and temperature=0 variants cover the "tuned prompt" surface with stronger metrics than a dedicated prompt-opt harness would produce. |
+| [#73 Maya's extractions use temperature + hybrid prompt](https://github.com/flexion/forms-lab/issues/73) | shipped ([PR #76](https://github.com/flexion/forms-lab/pull/76)) | `extraction/sonnet-temperature-zero`, `extraction/sonnet-hybrid-v1` | `/catalog/experiments/pdf-field-extraction/sonnet-temperature-zero.md`, `/catalog/experiments/pdf-field-extraction/sonnet-hybrid-v1.md`. Finding: hybrid-v1 wins the suite (precision 99.2%, recall 72.6%, sensitivity +23.8pp over baseline). Temp=0 alone is the largest precision lever (+15.1pp) but costs recall. Assignment 10's prompt-shape rank ordering (hybrid > few-shot > verbose) reproduces on Sonnet. |
 | [#65 Maya's extractions use our fine-tuned model](https://github.com/flexion/forms-lab/issues/65) | scope-deferred | — | `/catalog/experiments/pdf-field-extraction/lora-scope-deferral.md`. Deferred: prompt engineering achieves target quality on Claude; LoRA adds cost without new learning for this deadline. |
 | [#66 Maya extracts via structured tool-use](https://github.com/flexion/forms-lab/issues/66) | shipped | `extraction/tool-use-sonnet` | `/catalog/experiments/pdf-field-extraction/tool-use-sonnet.md`. Finding: precision 96.3%, sensitivity +51pp. Constrained output eliminates hallucination at cost of recall (step-limit). |
 
 ## Priority tiers
 
-**Tier 1 — must land for presentation.** #10 trunk, plus at least one story from each of the picker-tab and capability tracks, plus prompt optimization. These together demonstrate evaluation, model selection, and one prompt-engineering technique — the core of the rubric.
+**Tier 1 — must land for presentation.** Shipped. #10 trunk (variant picker) plus #59 shaping-model picker, #63 few-shot, #66 tool-use.
 
-**Tier 2 — should land.** Additional picker tabs, few-shot, structured tool-use. Each adds breadth.
+**Tier 2 — should land.** Shipped. #73 prompt optimization (hybrid + temperature=0), #74 RAG (with policy corpus), #75 live shaping eval runner.
 
-**Tier 3 — aspirational.** LoRA + inference endpoint. Captured as a story even if we don't ship it — the catalog will reflect "scope-deferred" with the why.
+**Tier 3 — aspirational.** #60 filling-model picker and #65 LoRA remain deferred — neither is required for the rubric. #65 is a documented scope-deferral; #60 is feasible post-presentation if a filling-comparison narrative is wanted.
 
 ## Conventions
 

--- a/notes/experiment-orchestration.md
+++ b/notes/experiment-orchestration.md
@@ -8,7 +8,9 @@ created: 2026-04-19
 
 ## 1. Purpose
 
-This document is the executable handoff for the eight follow-up experiment stories (#59–#66) filed after PR #58 (story 10 variant picker). Any future Claude Code session picks this file up, reads the status table, and dispatches the next story without needing prior conversation history. There is no separate coordinator service or automation — discipline enforced by a single doc is cheaper and more adaptable than code given the presentation deadline (~2026-04-20) and the small, bounded scope. The "orchestration" is: read this file, pick the next story, execute the playbook, update the table, commit. Humans read it too — the status table is the single source of truth the user checks between sessions.
+This document is the executable handoff for the eight follow-up experiment stories (#59–#66, plus the tier-2 follow-ups #73–#75) filed after PR #58 (story 10 variant picker). Any future Claude Code session picks this file up, reads the status table, and dispatches the next story without needing prior conversation history. There is no separate coordinator service or automation — discipline enforced by a single doc is cheaper and more adaptable than code given the presentation deadline (~2026-04-20) and the small, bounded scope. The "orchestration" is: read this file, pick the next story, execute the playbook, update the table, commit. Humans read it too — the status table is the single source of truth the user checks between sessions.
+
+**Current status (2026-04-19):** All prompted work shipped. Tier-1 (#59, #63, #66) and tier-2 (#73, #74, #75) are merged to main and deployed. #62 was merged as #74 (it was a duplicate). #64 scope-deferred (superseded by #73). #60 and #65 remain as planned/deferred tier-3 work — not required for the 2026-04-20 presentation. No in-flight experiment branches; the only active surface is pre-existing UX work on story-9 (PR #83).
 
 ## 2. Current state
 
@@ -17,14 +19,14 @@ This document is the executable handoff for the eight follow-up experiment stori
 | #59 | Maya chooses her shaping model | **shipped** | merged (PR #69) | 1 | — |
 | #60 | Carlos's conversation uses a chosen model | planned | — | 3 | #58 + #9 |
 | #61 | Maya verifies AcroForm mapping | planned | — | 2 | — |
-| #62 | Maya's extractions cite the law (RAG) | planned | — | 2 | — |
+| #62 | Maya's extractions cite the law (RAG) | **shipped** | merged as #74 / PR #78 | 2 | Duplicate of #74; see that row |
 | #63 | Maya's extractions learn from curated examples (few-shot) | **shipped** | merged (PR #67) | 1 | — |
-| #64 | Maya's extractions use a tuned prompt (prompt-opt) | planned | — | 2 | — |
+| #64 | Maya's extractions use a tuned prompt (prompt-opt) | **scope-deferred** | — | 2 | Superseded by #73 — hybrid-v1 and temperature=0 variants already deliver prompt-engineering evidence across the suite with stronger metrics than a dedicated prompt-opt harness would produce |
 | #65 | Maya's extractions use our fine-tuned model (LoRA) | **scope-deferred** | — | 3 | See catalog/experiments/pdf-field-extraction/lora-scope-deferral.md |
 | #66 | Maya extracts via structured tool-use | **shipped** | merged (PR #68) | 1 | — |
 | #73 | Prompt optimization (hybrid/temperature) | **shipped** | merged (PR #76) | 2 | Hybrid-v1 wins suite (precision 99.2%, recall 72.6%); temp=0 ablation shows +15.1pp precision at -9.9pp recall |
-| #74 | RAG extraction variant | **pr-open** | [PR #78](https://github.com/flexion/forms-lab/pull/78) | 2 | Sensitivity +25.3pp, precision +13.6pp, recall -5.7pp |
-| #75 | Live shaping model evaluation | **shipped** | merged (PR #77) | 2 | Opus 73/83/67%, Sonnet 67/75/62%, Haiku 67/83/62%. |
+| #74 | RAG extraction variant | **shipped** | merged (PR #78) | 2 | Sensitivity +25.3pp, precision +13.6pp, recall -5.7pp |
+| #75 | Live shaping model evaluation | **shipped** | merged (PR #77) | 2 | Opus 73/83/67%, Sonnet 67/75/62%, Haiku 67/83/62% (kind-recall / kind-precision / argument-accuracy). |
 
 **How to update this table** — edit it in a commit alongside any status change. This file is the source of truth; the catalog roadmap (`catalog/experiments/_roadmap.md`) mirrors it. Statuses: `planned` → `in-progress` → `pr-open` → `shipped`, or `scope-deferred` if cut.
 

--- a/notes/flight-board.md
+++ b/notes/flight-board.md
@@ -4,14 +4,28 @@
 
 | Story | Branch | Status | Worktree | Updated |
 |-------|--------|--------|----------|---------|
-| #5 Maya reviews proposed changes | story-5/review-changes | merged (#43) | .worktrees/story-5-review-changes | 2026-04-18 |
-| #7 Maya receives a completed PDF | story-7/completed-pdf | merged (#22) | .worktrees/story-7-completed-pdf | 2026-04-19 |
 | #9 Carlos completes complex sections through conversation | story-9/conversational-sections | in-progress | .worktrees/story-9-conversational-sections | 2026-04-18 |
-| #71 Developer navigates LLM integrations via a screaming service layer | story-71/llm-integrations-catalog | pr-open ([#84](https://github.com/flexion/forms-lab/pull/84)) | .worktrees/story-71-llm-integrations-catalog | 2026-04-19 |
+| #9 UX fixes (live field updates, loading, context) | story-9/ux-fixes | pr-open ([#83](https://github.com/flexion/forms-lab/pull/83)) | main repo checkout | 2026-04-19 |
 
 ## Landed
 
+Most recent first.
+
 | Story | Branch | Status | PR | Merged |
 |-------|--------|--------|----|--------|
-| #4 Maya shapes the form experience (chat) | story-4/form-shaping | shipped | #42 | 2026-04-15 |
-| #4 Maya shapes the form experience (direct-edit UI) | story-4/direct-edit-ui | shipped | #54 | 2026-04-17 |
+| #71 Developer navigates LLM integrations via a screaming service layer | story-71/llm-integrations-catalog | shipped | [#84](https://github.com/flexion/forms-lab/pull/84) | 2026-04-19 |
+| #74 Maya's extractions cite the law (RAG) | experiment/74-rag-extraction | shipped | [#78](https://github.com/flexion/forms-lab/pull/78) | 2026-04-19 |
+| #75 Run live shaping model evaluation | experiment/75-shaping-eval | shipped | [#77](https://github.com/flexion/forms-lab/pull/77) | 2026-04-19 |
+| #73 Prompt optimization (hybrid + temperature=0) | experiment/73-prompt-optimization | shipped | [#76](https://github.com/flexion/forms-lab/pull/76) | 2026-04-19 |
+| Infra: systemd generator install fix | infra/2026-04-19-generator-fix | shipped | [#82](https://github.com/flexion/forms-lab/pull/82) | 2026-04-19 |
+| Infra: pulumi t3.medium, systemd-generator reboot-safety, branch-delete teardown | infra/2026-04-19-deploy-hardening | shipped | [#81](https://github.com/flexion/forms-lab/pull/81) | 2026-04-19 |
+| Infra: `[Install]` on app template | infra/2026-04-19-app-install-section | shipped | [#80](https://github.com/flexion/forms-lab/pull/80) | 2026-04-19 |
+| Infra: reboot-safe branch apps + webhook mid-build recovery | infra/2026-04-19-reboot-safe-apps | shipped | [#79](https://github.com/flexion/forms-lab/pull/79) | 2026-04-19 |
+| #66 Maya extracts via structured tool-use | experiment/66-tool-use | shipped | [#68](https://github.com/flexion/forms-lab/pull/68) | 2026-04-19 |
+| #63 Maya's extractions learn from curated examples (few-shot) | experiment/63-few-shot | shipped | [#67](https://github.com/flexion/forms-lab/pull/67) | 2026-04-19 |
+| #59 Maya chooses her shaping model | experiment/59-shaping-model-comparison | shipped | [#69](https://github.com/flexion/forms-lab/pull/69) | 2026-04-19 |
+| #10 Maya chooses how her form was extracted (variant picker) | story-10/variant-picker | shipped | [#58](https://github.com/flexion/forms-lab/pull/58) | 2026-04-19 |
+| #5 Maya reviews proposed changes | story-5/review-changes | shipped | [#43](https://github.com/flexion/forms-lab/pull/43) | 2026-04-18 |
+| #4 Maya shapes the form experience (direct-edit UI) | story-4/direct-edit-ui | shipped | [#54](https://github.com/flexion/forms-lab/pull/54) | 2026-04-17 |
+| #4 Maya shapes the form experience (chat) | story-4/form-shaping | shipped | [#42](https://github.com/flexion/forms-lab/pull/42) | 2026-04-15 |
+| #7 Maya receives a completed PDF | story-7/completed-pdf | shipped | [#22](https://github.com/flexion/forms-lab/pull/22) | 2026-04-19 |


### PR DESCRIPTION
## Context

Post-merge sweep after today's three tier-2 PRs (#76/#77/#78) landed. Three source-of-truth docs were out of date — this brings them back in line.

## Changes

- `notes/experiment-orchestration.md`:
  - #74 flipped pr-open → shipped (merged as PR #78).
  - #62 flipped planned → shipped (was a duplicate; same code/finding as #74).
  - #64 flipped planned → scope-deferred, noting that #73's hybrid-v1 + temperature=0 variants already cover the tuned-prompt surface with stronger metrics than a dedicated prompt-opt harness would produce.
  - Current Status block added to §1 so a future session reads the shipped state first.

- `catalog/experiments/_roadmap.md`:
  - #10, #73, #74, #75 flipped to shipped with PR links.
  - #64 flipped to scope-deferred.
  - Priority Tiers section refreshed — tier-1 and tier-2 done; only #60 and #65 remain in tier-3.

- `notes/flight-board.md`:
  - In-Flight table cleaned to the two actual in-flight items (both on story-9).
  - Landed table reconstructed with every tier-1/tier-2 PR from this week plus the four infra-hardening PRs from today's incident. Most recent first.

## Testing

- [x] `bun run check` — 1269/0
- Docs-only change; no runtime effect.