### PR TITLE
docs(catalog): close out story #7 and sync stories

### DIFF
--- a/catalog/stories/14-developer-establishes-and-maintains-a-living-threat-model.md
+++ b/catalog/stories/14-developer-establishes-and-maintains-a-living-threat-model.md
@@ -3,8 +3,8 @@ issue: 14
 title: Developer establishes and maintains a living threat model
 milestone: "Final Project"
 labels: [user-story]
-state: open
-synced_at: 2026-04-09T14:40:12.308Z
+state: closed
+synced_at: 2026-04-20T15:40:03.188Z
 ---
 
 ## User Story:

--- a/catalog/stories/2-maya-signs-in-to-access-form-authoring.md
+++ b/catalog/stories/2-maya-signs-in-to-access-form-authoring.md
@@ -3,8 +3,8 @@ issue: 2
 title: Maya signs in to access form authoring
 milestone: "Final Project"
 labels: [user-story]
-state: open
-synced_at: 2026-04-09T14:40:12.309Z
+state: closed
+synced_at: 2026-04-20T15:40:03.188Z
 ---
 
 ## User Story:
@@ -18,13 +18,13 @@ As a **form creator (Maya)**, in order to **securely access form authoring tools
 
 ## Acceptance Criteria:
 
-- [ ] Sign-in link visible on public pages
-- [ ] Clicking sign-in initiates GitHub OAuth flow
-- [ ] After authentication, user sees their identity (name/avatar) in the header
-- [ ] Authenticated users see authoring navigation (e.g., "My Projects", "Upload Form")
-- [ ] Unauthenticated users see only public catalog content
-- [ ] Sign-out clears the session
-- [ ] Auth middleware protects authoring routes, redirects to sign-in
+- [x] Sign-in link visible on public pages
+- [x] Clicking sign-in initiates GitHub OAuth flow
+- [x] After authentication, user sees their identity (name/avatar) in the header
+- [x] Authenticated users see authoring navigation (e.g., "My Projects", "Upload Form")
+- [x] Unauthenticated users see only public catalog content
+- [x] Sign-out clears the session
+- [x] Auth middleware protects authoring routes, redirects to sign-in
 
 ## Success Metrics:
 
@@ -41,10 +41,10 @@ As a **form creator (Maya)**, in order to **securely access form authoring tools
 
 ## Definition of Done:
 
-- [ ] Acceptance criteria met
-- [ ] Threat model updated -- any new trust boundaries, data flows, or attack surfaces are reflected in `catalog/architecture/threat-model.md`
-- [ ] Technical documentation updated -- architecture docs and decisions are current
-- [ ] Tests pass including auth middleware tests
-- [ ] Type checking passes
-- [ ] CI pipeline green
-- [ ] Deployed and demoable
+- [x] Acceptance criteria met
+- [x] Threat model updated -- any new trust boundaries, data flows, or attack surfaces are reflected in `catalog/architecture/threat-model.md`
+- [x] Technical documentation updated -- architecture docs and decisions are current
+- [x] Tests pass including auth middleware tests
+- [x] Type checking passes
+- [x] CI pipeline green
+- [x] Deployed and demoable

--- a/catalog/stories/3-maya-uploads-a-pdf-and-reviews-the-extracted-specs.md
+++ b/catalog/stories/3-maya-uploads-a-pdf-and-reviews-the-extracted-specs.md
@@ -3,8 +3,8 @@ issue: 3
 title: Maya uploads a PDF and reviews the extracted specs
 milestone: "Final Project"
 labels: [user-story, llm-integration]
-state: open
-synced_at: 2026-04-09T14:40:12.308Z
+state: closed
+synced_at: 2026-04-20T15:40:03.188Z
 ---
 
 ## User Story:
@@ -18,14 +18,23 @@ As a **form creator (Maya)**, in order to **digitize a paper form without techni
 
 ## Acceptance Criteria:
 
-- [ ] Upload page accepts PDF files
-- [ ] System extracts structure from PDF and produces a DataCollectionSpec
-- [ ] System generates a default FormSpec based on the extracted DataCollectionSpec
-- [ ] Both specs are displayed in the catalog as browsable, reviewable content
-- [ ] Maya can see what fields were extracted, their types, grouping, and conditions
-- [ ] Maya can see the proposed form layout (pages, sections, delivery modes)
-- [ ] Extracted specs are persisted as a FormProject in git
-- [ ] Extraction errors or low-confidence fields are flagged for review
+- [x] Upload page accepts PDF files
+- [x] System extracts structure from PDF and produces a DataCollectionSpec
+- [x] System generates a default FormSpec based on the extracted DataCollectionSpec
+- [x] Both specs are displayed in the catalog as browsable, reviewable content
+- [x] Maya can see what fields were extracted, their types, grouping, and conditions
+- [x] Maya can see the proposed form layout (pages, sections, delivery modes)
+- [x] Extracted specs are persisted as a FormProject in git
+- [x] Extraction errors or low-confidence fields are flagged for review
+- [x] Form projects are stored as bare git repos with version history
+- [x] Project detail page shows version history with commit-level snapshots
+- [x] Projects are publicly viewable at user-scoped URLs (/:owner/:slug)
+- [x] Mutations (delete, re-extract) are restricted to project owners via service-layer permission checks
+- [x] Authenticated users can fork projects they do not own
+- [x] User profile pages list a user's projects at /:owner
+- [x] Git repository browsing (tree, blob, commits) available at GitHub-style URLs
+- [x] Read-only git clone served over HTTP
+- [x] Home page shows dashboard for authenticated users, landing page for anonymous visitors
 
 ## Success Metrics:
 
@@ -39,16 +48,18 @@ As a **form creator (Maya)**, in order to **digitize a paper form without techni
 - LLM service uses strategy pattern: `PdfExtractor` interface with `ApiPdfExtractor` implementation
 - Evaluation: compare extracted spec against manually-created ground truth for test PDFs
 - Future experiments: alternative models, prompting strategies, chunking approaches
-- FormProject created on upload: `projects/<slug>/spec.json`, `projects/<slug>/form.json`, `projects/<slug>/source.pdf`
+- Form projects stored as bare git repos at `data/repos/<slug>.git`
+- ProjectService layer enforces ownership permissions; route handlers are thin wrappers
+- GitHub-style URL structure: `/:owner/:slug`, `/:owner/:slug/tree/:ref/*`, `/:owner/:slug/settings`, etc.
 
 ## Definition of Done:
 
-- [ ] Acceptance criteria met
-- [ ] Threat model updated -- any new trust boundaries, data flows, or attack surfaces are reflected in `catalog/architecture/threat-model.md`
-- [ ] Technical documentation updated -- architecture docs and decisions are current
-- [ ] LLM extraction service has interface abstraction (swappable implementations)
-- [ ] At least one test PDF with ground truth for evaluation
-- [ ] Tests pass
-- [ ] Type checking passes
-- [ ] CI pipeline green
-- [ ] Deployed and demoable
+- [x] Acceptance criteria met
+- [x] Threat model updated -- any new trust boundaries, data flows, or attack surfaces are reflected in `catalog/architecture/threat-model.md`
+- [x] Technical documentation updated -- architecture docs and decisions are current
+- [x] LLM extraction service has interface abstraction (swappable implementations)
+- [x] At least one test PDF with ground truth for evaluation
+- [x] Tests pass
+- [x] Type checking passes
+- [x] CI pipeline green
+- [x] Deployed and demoable

--- a/catalog/stories/4-maya-shapes-the-form-experience.md
+++ b/catalog/stories/4-maya-shapes-the-form-experience.md
@@ -3,13 +3,13 @@ issue: 4
 title: Maya shapes the form experience
 milestone: "Final Project"
 labels: [user-story, llm-integration]
-state: open
-synced_at: 2026-04-09T14:40:12.308Z
+state: closed
+synced_at: 2026-04-20T15:40:03.188Z
 ---
 
 ## User Story:
 
-As a **form creator (Maya)**, in order to **control how applicants experience the form**, I want **to reorder pages, adjust section grouping, pick delivery modes, and see a live preview of my changes**
+As a **form creator (Maya)**, in order to **control how applicants experience the form**, I want **to shape the form structure using natural language and manual controls, with a live preview of my changes**
 
 ## Preconditions:
 
@@ -18,61 +18,28 @@ As a **form creator (Maya)**, in order to **control how applicants experience th
 
 ## Acceptance Criteria:
 
-- [x] Maya can view the current FormSpec for a project
-- [x] Maya can describe changes in natural language and see the LLM propose concrete edits
-- [x] Proposed edits are shown as a humanized command list (the commands *are* the diff)
-- [x] Maya can accept, reject, or refine an LLM-proposed batch
-- [x] Maya can directly manipulate pages (rename, add, delete, reorder, set delivery mode)
-- [x] Maya can directly manipulate groups (rename, add, delete, add field)
-- [x] Maya can directly manipulate fields (rename, required toggle, change type/control/sensitivity, set condition, move, delete)
-- [x] Direct edits and LLM-accepted batches stage into one buffer; one Save = one git commit
-- [x] Save enforces optimistic concurrency via `parentSha` to prevent two-tab clobbering
-- [x] Preview renders the page as Carlos would see it; "Preview as applicant" toggles between edit and applicant view
-- [x] Changes are durably recorded in git plus a structured `shaping-log.json`
-- [ ] Dedicated one-click "suggest delivery modes" button (partial — the LLM can emit `setDeliveryMode` via tool use, but no dedicated button)
+- [ ] Maya can view the current FormSpec for a project
+- [ ] Maya can describe changes in natural language (e.g., "add an eligibility screener before page 5")
+- [ ] LLM proposes concrete FormSpec edits based on Maya's intent and the underlying DataCollectionSpec
+- [ ] Maya sees a clear before/after of proposed changes
+- [ ] Maya can accept or reject proposed changes
+- [ ] Maya can manually fine-tune: reorder pages, move groups between pages, set delivery mode per section
+- [ ] LLM suggests delivery modes based on section complexity
+- [ ] Live preview shows what Carlos would see
+- [ ] Changes are saved to the FormSpec
 
 ## Success Metrics:
 
 - Maya can complete a form shaping session in under 10 minutes
+- LLM-assisted edits align with Maya's stated intent
 - LLM delivery mode suggestions align with section complexity
 
 ## Notes:
 
-- Direct manipulation and LLM assistance share one foundation: both emit the same `Command` values, both stage into one client buffer, both commit via `POST /edit/save`. See [Unified staged buffer](../decisions/architecture/unified-staged-buffer.md).
-- The LLM uses constrained generation: each command kind is an AI SDK tool with a Zod schema. See [LLM tool-use as validation boundary](../decisions/architecture/llm-tool-use-as-validation-boundary.md).
-- Commands span both domain layers (structural edits to `FormSpec`, field edits to `DataCollectionSpec`). This is a deliberate broadening of Story 3's extraction output. See [Command-based form shaping](../decisions/architecture/command-based-shaping.md).
-- The editor UI uses a coordinator custom-element pattern rather than a client framework. See [Coordinator custom elements](../decisions/architecture/coordinator-custom-elements.md).
-- Context for why the implementation pivoted mid-story: [Shaping architecture experiment](../experiments/shaping-architecture/).
-
-## Implementation Notes:
-
-**Shipped (PR #42 — command-based shaping):**
-
-- Command vocabulary spanning page, group, and field operations (`src/services/forms/shaping/commands.ts`)
-- Atomic batch executor with rollback (`executor.ts`)
-- AI SDK tool-use integration against Bedrock (`bedrock-shaper.ts`, `tools.ts`)
-- Humanizer that renders commands as natural-language lines (`humanize.ts`)
-- Three-panel editor layout (structure / preview / assistant) with collapsible panels
-- Git-backed audit trail: one commit per accepted batch plus structured `shaping-log.json`
-- Accept / reject / refine loop with persistent chat transcript
-
-**Shipped (PR #54 — direct-manipulation edit UI):**
-
-- WYSIWYG editors for page/group/field (`flex-editable-page`, `flex-editable-group`, `flex-editable-field`) — click-to-edit labels, chips for type/required, "…more" expander for sensitivity/control/condition/move-to-group/change-type
-- Unified staged-changes buffer held by `flex-form-editor`; `flex-staged-changes` popover lists pending commands with per-entry remove
-- Single commit endpoint `POST /edit/save`; `/edit/accept` and `/edit/execute` removed
-- `parentSha` optimistic-concurrency guard on `/edit/save`; 409 on stale parent
-- `flex-editable-page` replaces the preview iframe; "Preview as applicant" toggle shows the applicant-facing view
-- `source` field on shaping-log entries (`manual` vs `llm`) preserved across the unified path
-
-**Deferred follow-ups:**
-
-- Dedicated one-click "suggest delivery modes" prompt button (LLM can emit the command today, but no dedicated button)
-- Drag-and-drop for pages/groups/fields (arrows + dropdowns cover the common case)
-- Server-side draft persistence — staged buffer is client-only; `beforeunload` warns on navigation
-- Live preview of conversational delivery mode
-- Playwright behavioral tests for custom elements (executor and integration-save tests are green; end-to-end custom-element tests remain)
-- Move shared `commands.ts` + `humanize.ts` to `src/shared/shaping/` to eliminate humanizer duplication — requires an ADR amendment to the `import type` exclusion in the dependency-rule test
+- LLM-assisted authoring is the primary workflow; manual controls are for fine-tuning
+- Story 5 handles proposal/draft semantics — Story 4 edits FormSpec directly
+- Live preview renders the form as Carlos would see it
+- FormSpec changes are persisted via existing ProjectStore
 
 ## Definition of Done:
 

--- a/catalog/stories/48-evaluator-experiences-a-guided-walkthrough-of-the-project.md
+++ b/catalog/stories/48-evaluator-experiences-a-guided-walkthrough-of-the-project.md
@@ -3,8 +3,8 @@ issue: 48
 title: Evaluator experiences a guided walkthrough of the project
 milestone: ""
 labels: [user-story]
-state: open
-synced_at: 2026-04-14T00:31:42.549Z
+state: closed
+synced_at: 2026-04-20T15:40:03.188Z
 ---
 
 ## User Story:

--- a/catalog/stories/5-maya-reviews-her-proposed-changes-before-publishing.md
+++ b/catalog/stories/5-maya-reviews-her-proposed-changes-before-publishing.md
@@ -3,13 +3,13 @@ issue: 5
 title: Maya reviews her proposed changes before publishing
 milestone: "Final Project"
 labels: [user-story]
-state: open
-synced_at: 2026-04-16T22:12:05.773Z
+state: closed
+synced_at: 2026-04-20T15:40:03.188Z
 ---
 
 ## User Story:
 
-As a **form creator (Maya)**, in order to **understand the impact of my changes before they go live**, I want **to see a semantic diff of my proposed specs compared to the published version, with side-by-side previews**
+As a **form creator (Maya)**, in order to **understand the impact of my changes before they go live**, I want **to see a semantic diff of my proposed specs compared to the published version, with a rendered preview**
 
 ## Preconditions:
 
@@ -18,22 +18,22 @@ As a **form creator (Maya)**, in order to **understand the impact of my changes 
 
 ## Acceptance Criteria:
 
-- [ ] Branch model: `main` is the published state; named branches are working copies
-- [ ] `main` is read-only in the editor; Maya must create or select a branch to edit
-- [ ] Branch indicator and switcher in the editor header
-- [ ] Change indicators on modified resources in the editor sidebar
-- [ ] PR-style review page at `/:owner/:slug/compare/:base...:branch`
-- [ ] Maya can view a structural semantic diff between base and branch DataCollectionSpec
-- [ ] Maya can view a structural semantic diff between base and branch FormSpec
-- [ ] Diffs are domain-aware: "Added page 'Military Service'", "Reordered 'Offense Information' to page 4", not raw JSON diffs
-- [ ] Command log shown as narrative context alongside structural diff (History tab)
-- [ ] Side-by-side rendered previews show how the form looks before and after
-- [ ] Maya can approve changes (merge branch to target)
-- [ ] Maya can reject changes (delete branch)
-- [ ] Comments on review pages (threads with author, timestamp, markdown body)
-- [ ] Branch-qualified form URLs for testing non-production forms (`/:owner/:slug/forms/:branch`)
-- [ ] Non-production forms display a visual preview banner
-- [ ] Submissions reference the exact commit SHA via `specVersion` field
+- [x] Branch model: `main` is the published state; named branches are working copies
+- [x] `main` is read-only in the editor; Maya must create or select a branch to edit
+- [x] Branch indicator and switcher in the editor header
+- [x] Change indicators on modified resources in the editor sidebar
+- [x] PR-style review page at `/:owner/:slug/compare/:base...:branch`
+- [x] Maya can view a structural semantic diff between base and branch DataCollectionSpec
+- [x] Maya can view a structural semantic diff between base and branch FormSpec
+- [x] Diffs are domain-aware: "Added page 'Military Service'", "Reordered 'Offense Information' to page 4", not raw JSON diffs
+- [x] Command log shown as narrative context alongside structural diff (History tab)
+- [x] Rendered preview of changes — delivered as an annotated single view (flex-spec-diff-browser) rather than a literal side-by-side. See `notes/story-5-review-changes/preview-diff-design.md` for the rationale: an annotated single view reads cleanly for both small refinements (collapses unchanged items) and initial imports (walks the form once with `+ New` badges), while literal side-by-side became a wall of text on large forms.
+- [x] Maya can approve changes (merge branch to target)
+- [x] Maya can reject changes (delete branch)
+- [x] Comments on review pages (threads with author, timestamp, markdown body)
+- [x] Branch-qualified form URLs for testing non-production forms (`/forms/:specId/branches/:branch`)
+- [x] Non-production forms display a visual preview banner
+- [x] Submissions reference the exact commit SHA via `specVersion` field
 
 ## Success Metrics:
 
@@ -44,16 +44,18 @@ As a **form creator (Maya)**, in order to **understand the impact of my changes 
 
 - Comparison follows GitHub conventions: `/:owner/:slug/compare/:base...:branch`
 - Review page has four tabs: Changes, Preview, History, Comments
-- Comments stored in the branch's bare repo (`reviews/base...branch/comments.json`)
+- Preview tab uses a single annotated head-side view (overview strip + collapsible pages/groups with inline change badges) rather than literal split; design documented at `notes/story-5-review-changes/preview-diff-design.md`.
+- Comments stored in the branch's bare repo (`reviews/base---branch/comments.json`)
 - Agentic comment-driven form evolution deferred to #52
 - Branch-qualified forms work identically to production forms; submissions are standard but tagged with branch commit SHA
+- PDF imports now land on an `import` branch for review-before-publish flow; project overview shows a "Pending review" banner with Review/Edit CTAs.
 
 ## Definition of Done:
 
-- [ ] Acceptance criteria met
-- [ ] Threat model updated -- any new trust boundaries, data flows, or attack surfaces are reflected in `catalog/architecture/threat-model.md`
-- [ ] Technical documentation updated -- architecture docs and decisions are current
-- [ ] Comparison and diff infrastructure works for DataCollectionSpec and FormSpec
-- [ ] Tests pass
-- [ ] Type checking passes
-- [ ] Deployed and demoable
+- [x] Acceptance criteria met
+- [x] Threat model reviewed — no new trust boundaries; existing coverage sufficient
+- [x] Technical documentation updated (design.md, preview-diff-design.md, review.md, session-log.md in notes/story-5-review-changes/)
+- [x] Comparison and diff infrastructure works for DataCollectionSpec and FormSpec
+- [x] Tests pass (707 tests, 0 failures)
+- [x] Type checking passes
+- [x] Deployed and demoable at https://ec2-34-197-222-16.compute-1.amazonaws.com/story-5-review-changes/

--- a/catalog/stories/52-llm-responds-to-review-comments-to-evolve-forms.md
+++ b/catalog/stories/52-llm-responds-to-review-comments-to-evolve-forms.md
@@ -4,7 +4,7 @@ title: LLM responds to review comments to evolve forms
 milestone: ""
 labels: [user-story]
 state: open
-synced_at: 2026-04-16T22:12:05.772Z
+synced_at: 2026-04-20T15:40:03.188Z
 ---
 
 ## User Story:

--- a/catalog/stories/59-maya-chooses-her-shaping-model.md
+++ b/catalog/stories/59-maya-chooses-her-shaping-model.md
@@ -1,0 +1,47 @@
+---
+issue: 59
+title: Maya chooses her shaping model
+milestone: "Final Project"
+labels: [user-story, llm-integration]
+state: closed
+synced_at: 2026-04-20T15:40:03.188Z
+---
+
+## User Story
+
+As **Maya**, in order to **choose which LLM drives form shaping and see how different models perform on that task**, I want **shaping variants to be selectable from Settings → Variants, backed by a quantitative benchmark**.
+
+## Preconditions
+
+- #58 (Story 10 variant picker) merged to main
+
+## Acceptance Criteria
+
+- [ ] New evaluation kind `shaping-commands` scores a variant against scripted intents with expected `Command[]` outputs (precision/recall on command-kind + args)
+- [ ] Variants registered: `shaping/haiku`, `shaping/sonnet` (promoted baseline), `shaping/opus`
+- [ ] Shaping tab in Settings → Variants renders all three variants with descriptions and Learn more links
+- [ ] Provenance recorded in `shaping-log.json` entries (extend existing entry schema with variantId + modelId)
+- [ ] `<VariantBadge task="shaping" ...>` rendered wherever shaping output is shown (review/compare views)
+- [ ] New catalog suite `catalog/experiments/shaping-model-comparison/` with `_suite.md`, `haiku.md`, `sonnet.md`, `opus.md`, each containing metrics, approach, and findings
+- [ ] `catalog/experiments/_roadmap.md` updated: row marked `shipped`, one-line finding added
+- [ ] Existing `catalog/experiments/shaping-architecture/` entries remain intact (architecture story is separate from model comparison)
+
+## Success Metrics
+
+- Meaningful recall/precision separation between variants across ~6 scripted intents (same set as the shaping-architecture qualitative comparison)
+- Picker UI renders cleanly on every screen that renders shaping output
+
+## Notes
+
+- Seeded intents already exist in `catalog/experiments/shaping-architecture/_suite.md` — reuse them as the benchmark corpus
+- `src/services/forms/shaping/registry.ts` already exists with a Sonnet-only entry — extend it, don't replace
+- The picker's filling/mapping tabs stay empty until their respective stories land
+
+## Definition of Done
+
+- [ ] Acceptance criteria met
+- [ ] Tests pass (bun run check)
+- [ ] Type checking passes
+- [ ] Threat model updated if security-relevant
+- [ ] CI pipeline green
+- [ ] Deployed and demoable

--- a/catalog/stories/6-carlos-fills-out-a-published-form.md
+++ b/catalog/stories/6-carlos-fills-out-a-published-form.md
@@ -3,8 +3,8 @@ issue: 6
 title: Carlos fills out a published form
 milestone: "Final Project"
 labels: [user-story]
-state: open
-synced_at: 2026-04-09T14:40:12.308Z
+state: closed
+synced_at: 2026-04-20T15:40:03.188Z
 ---
 
 ## User Story:

--- a/catalog/stories/60-carlos-s-conversation-uses-a-chosen-model.md
+++ b/catalog/stories/60-carlos-s-conversation-uses-a-chosen-model.md
@@ -1,0 +1,46 @@
+---
+issue: 60
+title: Carlos's conversation uses a chosen model
+milestone: "Final Project"
+labels: [user-story, llm-integration]
+state: open
+synced_at: 2026-04-20T15:40:03.187Z
+---
+
+## User Story
+
+As **Maya**, in order to **pick which LLM drives Carlos's conversational form-filling experience and see how different models perform on adaptive interviewing**, I want **filling variants to be selectable from Settings → Variants, backed by persona-driven evaluation**.
+
+## Preconditions
+
+- #58 (Story 10 variant picker) merged to main
+- #9 (Story 9 conversational sections) merged to main
+
+## Acceptance Criteria
+
+- [ ] New evaluation kind `filling-interview` scores a variant against scripted personas (completeness of collected fields + conditional routing accuracy), mirroring the assignment-10 TextGrad evaluator pattern
+- [ ] Variants registered: `filling/haiku`, `filling/sonnet`, `filling/opus`
+- [ ] Filling tab in Settings → Variants renders all three variants
+- [ ] Session records variantId at start (new column on form_sessions table)
+- [ ] `<VariantBadge task="filling" ...>` rendered on conversation UI
+- [ ] Persona fixtures committed (5 train + 3 test minimum)
+- [ ] New catalog suite `catalog/experiments/filling-model-comparison/` with `_suite.md` + one markdown per variant, each with metrics + findings
+- [ ] `catalog/experiments/_roadmap.md` updated with shipped status and one-line finding
+
+## Success Metrics
+
+- Observable tradeoff across variants (e.g., Opus higher completeness, Haiku faster/cheaper)
+- Persona-driven eval runs reproducibly from `bun run cli evaluate run <variant>`
+
+## Notes
+
+- Port evaluator shape from `llm-class-2026-winter-cohort/notes/assignment-10/` — persona-driven simulator + completeness scorer
+- Filling registry stub exists at `src/services/forms/filling/registry.ts` (empty); extend it
+
+## Definition of Done
+
+- [ ] Acceptance criteria met
+- [ ] Tests pass
+- [ ] Type checking passes
+- [ ] CI pipeline green
+- [ ] Deployed and demoable

--- a/catalog/stories/61-maya-verifies-acroform-mapping.md
+++ b/catalog/stories/61-maya-verifies-acroform-mapping.md
@@ -1,0 +1,45 @@
+---
+issue: 61
+title: Maya verifies AcroForm mapping
+milestone: "Final Project"
+labels: [user-story, llm-integration]
+state: open
+synced_at: 2026-04-20T15:40:03.187Z
+---
+
+## User Story
+
+As **Maya**, in order to **verify the field mapping between the extracted spec and the source PDF's AcroForm fields was done correctly and compare how different models handle mapping**, I want **field-mapping variants to be selectable from Settings → Variants, with mapping-accuracy evaluation**.
+
+## Preconditions
+
+- #58 (Story 10 variant picker) merged to main
+
+## Acceptance Criteria
+
+- [ ] New evaluation kind `field-mapping` scores spec-field → PDF-field matches against reviewed ground-truth mappings on the three fixtures (pardon, I-9, W-9)
+- [ ] Deterministic scorer (exact name match) and LLM-judge scorer (Opus) both implemented
+- [ ] Variants registered: `field-mapping/haiku`, `field-mapping/sonnet`, `field-mapping/opus`
+- [ ] Field-mapping tab in Settings → Variants renders all three variants
+- [ ] Provenance recorded for field-mapping in `forms/default/provenance.json` under `"field-mapping"` key
+- [ ] `<VariantBadge task="field-mapping" ...>` rendered on the edit/review UI where the mapping is visible
+- [ ] New catalog suite `catalog/experiments/field-mapping/` with `_suite.md` + variant pages containing metrics (recall, precision, confidence)
+- [ ] `catalog/experiments/_roadmap.md` updated with shipped status and one-line finding
+
+## Success Metrics
+
+- LLM-judge vs deterministic scorer deltas captured (demonstrates evaluation methodology affects measured performance)
+- Ground-truth mappings committed for at least the three existing fixtures
+
+## Notes
+
+- Mapping registry stub exists at `src/services/form-documents/mapping-registry.ts`; extend it
+- Field-mapping generation already occurs during extraction (see `src/services/form-documents/extraction.ts`) — this story is about making the model swappable and evaluating
+
+## Definition of Done
+
+- [ ] Acceptance criteria met
+- [ ] Tests pass
+- [ ] Type checking passes
+- [ ] CI pipeline green
+- [ ] Deployed and demoable

--- a/catalog/stories/62-maya-s-extractions-cite-the-law.md
+++ b/catalog/stories/62-maya-s-extractions-cite-the-law.md
@@ -1,0 +1,47 @@
+---
+issue: 62
+title: Maya's extractions cite the law
+milestone: "Final Project"
+labels: [user-story, llm-integration]
+state: closed
+synced_at: 2026-04-20T15:40:03.187Z
+---
+
+## User Story
+
+As **Maya**, in order to **trust that the LLM understood what my form is legally required to collect and defend that decision to stakeholders**, I want **extractions to cite the relevant regulatory text for each field, grounded via retrieval from a curated policy corpus**.
+
+## Preconditions
+
+- #58 (Story 10 variant picker) merged to main
+
+## Acceptance Criteria
+
+- [ ] New service `src/services/rag/` with embeddings client (Bedrock Titan or Voyage), in-memory cosine-similarity store, and a minimal retrieval API
+- [ ] Policy corpus committed under `catalog/references/` or similar — CFR/USC excerpts relevant to the existing fixture forms (immigration for I-9, tax for W-9, criminal for pardon)
+- [ ] New variant `extraction/sonnet-with-rag` that retrieves top-k policy chunks per section and attaches citations to each field's `description`
+- [ ] Extraction tab in Settings → Variants lists the RAG variant with a Learn more link to its catalog page
+- [ ] Generated spec fields include a `citation` field (extend `DataCollectionSpec` schema)
+- [ ] Evaluation run comparing `sonnet` vs `sonnet-with-rag` on sensitivity/type accuracy (hypothesis: grounding improves sensitivity labels, may hurt or help recall)
+- [ ] New catalog page `catalog/experiments/pdf-field-extraction/sonnet-with-rag.md` with approach, corpus used, metrics, and findings
+- [ ] `catalog/experiments/_roadmap.md` updated with shipped status and one-line finding
+
+## Success Metrics
+
+- Every extracted field in the RAG variant output has at least one citation attached, OR the catalog page documents why some fields have none
+- Measurable delta on sensitivity accuracy between baseline and RAG variants
+
+## Notes
+
+- Class topic: RAG, grounding, vector DB (Ch 9 in the syllabus)
+- Consider in-memory store for simplicity — no external vector DB dependency this round
+- Citations should reference source + section (e.g., "8 CFR 274a.2(b)(1)(i)(A) — List A identity and employment authorization")
+
+## Definition of Done
+
+- [ ] Acceptance criteria met
+- [ ] Tests pass
+- [ ] Type checking passes
+- [ ] Threat model updated (external knowledge source introduced)
+- [ ] CI pipeline green
+- [ ] Deployed and demoable

--- a/catalog/stories/63-maya-s-extractions-learn-from-curated-examples.md
+++ b/catalog/stories/63-maya-s-extractions-learn-from-curated-examples.md
@@ -1,0 +1,45 @@
+---
+issue: 63
+title: Maya's extractions learn from curated examples
+milestone: "Final Project"
+labels: [user-story, llm-integration]
+state: closed
+synced_at: 2026-04-20T15:40:03.187Z
+---
+
+## User Story
+
+As **Maya**, in order to **improve extraction quality on complex government forms by teaching the model what good output looks like**, I want **an extraction variant that uses curated few-shot examples without requiring fine-tuning**.
+
+## Preconditions
+
+- #58 (Story 10 variant picker) merged to main
+
+## Acceptance Criteria
+
+- [ ] New variant `extraction/few-shot-sonnet` that prepends 2-3 canonical (PDF description → spec) exemplar pairs to the extraction prompt
+- [ ] Exemplars committed under `src/services/extraction/exemplars/` (or similar); each includes a short description, a compact spec, and rationale for inclusion
+- [ ] Extraction tab in Settings → Variants lists the few-shot variant
+- [ ] Evaluation run comparing `sonnet` baseline vs `few-shot-sonnet` on all three fixtures with the LLM-judge scorer
+- [ ] Both scorers (deterministic + LLM-judge) reported
+- [ ] New catalog page `catalog/experiments/pdf-field-extraction/few-shot-sonnet.md` with exemplar descriptions, approach, metrics, and findings on what the exemplars seemed to help with
+- [ ] `catalog/experiments/_roadmap.md` updated with shipped status and one-line finding
+
+## Success Metrics
+
+- Non-trivial delta (positive or negative) in at least one metric vs the Sonnet baseline — teaches us something either way
+- Exemplars are documented well enough that another contributor could add more
+
+## Notes
+
+- Class topic: prompt conditioning (Ch 8)
+- Keep exemplar count small (2-3) to avoid blowing token budget
+- Consider exemplars that deliberately demonstrate edge cases (nested groups, sensitivity labels, conditional fields)
+
+## Definition of Done
+
+- [ ] Acceptance criteria met
+- [ ] Tests pass
+- [ ] Type checking passes
+- [ ] CI pipeline green
+- [ ] Deployed and demoable

--- a/catalog/stories/64-maya-s-extractions-use-a-tuned-prompt.md
+++ b/catalog/stories/64-maya-s-extractions-use-a-tuned-prompt.md
@@ -1,0 +1,47 @@
+---
+issue: 64
+title: Maya's extractions use a tuned prompt
+milestone: "Final Project"
+labels: [user-story, llm-integration]
+state: open
+synced_at: 2026-04-20T15:40:03.187Z
+---
+
+## User Story
+
+As **Maya**, in order to **get better extraction quality without changing the underlying model**, I want **an extraction variant whose system prompt has been automatically optimized against the evaluation suite**.
+
+## Preconditions
+
+- #58 (Story 10 variant picker) merged to main
+
+## Acceptance Criteria
+
+- [ ] New service `src/services/prompt-optimization/` — thin wrapper around TextGrad (or equivalent) that drives our existing `EvaluationKind` harness as its training signal
+- [ ] Optimization script produces a concrete optimized prompt for extraction, committed as a file under `src/services/extraction/prompts/optimized-v1.txt` (or similar)
+- [ ] New variant `extraction/sonnet-optimized-v1` that loads the optimized prompt at construction
+- [ ] Extraction tab in Settings → Variants lists the optimized variant
+- [ ] Evaluation run comparing baseline `sonnet` vs `sonnet-optimized-v1` on all fixtures
+- [ ] New catalog page `catalog/experiments/pdf-field-extraction/sonnet-optimized-v1.md` including: optimization setup (epochs, batch size, forward/backward models), before/after prompt snippets, and metric deltas
+- [ ] `catalog/experiments/_roadmap.md` updated with shipped status and one-line finding
+- [ ] Harness documented well enough that follow-on stories can run it against shaping and filling suites
+
+## Success Metrics
+
+- Optimized variant beats baseline on at least one metric (recall, precision, or sensitivity)
+- Optimization is reproducible via a single CLI command
+
+## Notes
+
+- Class topic: prompt optimization, Assignment 10
+- Use Opus as the backward model if it fits the budget; Sonnet otherwise
+- Document hyperparameters for reproducibility
+- Follow-on stories (not in scope here): `shaping/sonnet-optimized-v1`, `filling/sonnet-optimized-v1` — same harness, different eval kind
+
+## Definition of Done
+
+- [ ] Acceptance criteria met
+- [ ] Tests pass
+- [ ] Type checking passes
+- [ ] CI pipeline green
+- [ ] Deployed and demoable

--- a/catalog/stories/65-maya-s-extractions-use-our-fine-tuned-model.md
+++ b/catalog/stories/65-maya-s-extractions-use-our-fine-tuned-model.md
@@ -1,0 +1,51 @@
+---
+issue: 65
+title: Maya's extractions use our fine-tuned model
+milestone: "Final Project"
+labels: [user-story, llm-integration]
+state: open
+synced_at: 2026-04-20T15:40:03.187Z
+---
+
+## User Story
+
+As **Maya**, in order to **demonstrate that a small fine-tuned model can match or beat prompted larger models on a narrow domain task**, I want **an extraction variant powered by a LoRA fine-tune of a small open model, served from our own inference endpoint**.
+
+## Preconditions
+
+- #58 (Story 10 variant picker) merged to main
+- Training data pipeline exists (can be bootstrapped in this story)
+
+## Acceptance Criteria
+
+- [ ] Training dataset committed under `data/fine-tuning/extraction/` — at least 50 (PDF description → spec) pairs, either hand-curated from fixtures or Opus-generated and reviewed
+- [ ] LoRA fine-tuning script under `scripts/fine-tune-extraction.ts` (or language appropriate to the trainer)
+- [ ] Trained adapter checkpoint committed or clearly documented with retrieval instructions
+- [ ] FastAPI inference endpoint deployed to existing EC2, reachable via the app's Caddy routing — separate NixOS service, managed alongside the main app
+- [ ] New variant `extraction/lora-v1` in the extraction registry that calls the inference endpoint via HTTP
+- [ ] Extraction tab in Settings → Variants lists the LoRA variant
+- [ ] Evaluation run comparing the LoRA variant against Sonnet/Haiku baselines
+- [ ] New catalog page `catalog/experiments/pdf-field-extraction/lora-v1.md` including: base model, training data size, LoRA rank/alpha, training hyperparameters, deployment architecture, and metric deltas vs baselines
+- [ ] `catalog/experiments/_roadmap.md` updated with shipped status and one-line finding
+- [ ] If scope becomes unachievable (time/cost), catalog page clearly marks `scope-deferred` with reasoning — "attempted" is an honest outcome
+
+## Success Metrics
+
+- Either: the LoRA variant ships and hits a reasonable recall number (>50%), OR the catalog honestly documents what was attempted and what blocked shipping
+- If shipped, cost-per-extraction documented vs API variants
+
+## Notes
+
+- Class topic: fine-tuning (Ch 5), MLOps (Ch 4), production deployment (Ch 6) — the headline rubric item
+- Base model choice: smallest viable — Llama 3.2 3B or Mistral 7B
+- Cost gate: explicit user approval before GPU training spend
+- This is the most ambitious story; acceptable to scope-defer with a written explanation
+
+## Definition of Done
+
+- [ ] Acceptance criteria met (or clearly documented scope-deferral)
+- [ ] Tests pass
+- [ ] Type checking passes
+- [ ] Threat model updated (new service, new external training process)
+- [ ] CI pipeline green
+- [ ] Deployed and demoable

--- a/catalog/stories/66-maya-extracts-via-structured-tool-use.md
+++ b/catalog/stories/66-maya-extracts-via-structured-tool-use.md
@@ -1,0 +1,44 @@
+---
+issue: 66
+title: Maya extracts via structured tool-use
+milestone: "Final Project"
+labels: [user-story, llm-integration]
+state: closed
+synced_at: 2026-04-20T15:40:03.187Z
+---
+
+## User Story
+
+As **Maya**, in order to **get extractions that can't produce invalid JSON because the model is constrained by schema at generation time**, I want **an extraction variant that uses AI SDK tool-use instead of free-JSON prompting**.
+
+## Preconditions
+
+- #58 (Story 10 variant picker) merged to main
+
+## Acceptance Criteria
+
+- [ ] New variant `extraction/tool-use-sonnet` using AI SDK tool-use with one tool per top-level spec operation (add_group, add_field, set_conditions, etc.) — same pattern established for shaping
+- [ ] Validation failure rate tracked during evaluation runs (count of responses that fail the output schema pre-retry)
+- [ ] Extraction tab in Settings → Variants lists the tool-use variant
+- [ ] Evaluation run comparing baseline Sonnet (free-JSON) vs tool-use on all fixtures
+- [ ] New catalog page `catalog/experiments/pdf-field-extraction/tool-use-sonnet.md` including: tool vocabulary, validation-failure-rate comparison, and metric deltas
+- [ ] `catalog/experiments/_roadmap.md` updated with shipped status and one-line finding
+
+## Success Metrics
+
+- Zero schema-validation failures on tool-use variant (by construction)
+- Meaningful comparison vs free-JSON baseline on extraction quality metrics — demonstrates whether structural constraint helps or hurts content quality
+
+## Notes
+
+- Class topic: constrained generation (Ch 7)
+- Pattern already exists for shaping at `src/services/forms/shaping/tools.ts` — study it before implementing
+- Tool vocabulary should be small — the goal is demonstrating constrained output, not reinventing the extraction schema
+
+## Definition of Done
+
+- [ ] Acceptance criteria met
+- [ ] Tests pass
+- [ ] Type checking passes
+- [ ] CI pipeline green
+- [ ] Deployed and demoable

--- a/catalog/stories/7-maya-receives-a-completed-pdf.md
+++ b/catalog/stories/7-maya-receives-a-completed-pdf.md
@@ -3,8 +3,8 @@ issue: 7
 title: Maya receives a completed PDF
 milestone: "Final Project"
 labels: [user-story]
-state: open
-synced_at: 2026-04-09T14:40:12.308Z
+state: closed
+synced_at: 2026-04-20T15:40:03.188Z
 ---
 
 ## User Story:
@@ -18,11 +18,11 @@ As a **form creator (Maya)**, in order to **process applications using existing 
 
 ## Acceptance Criteria:
 
-- [ ] Maya can view a list of submissions for her forms
-- [ ] Maya can select a submission and download a completed PDF
-- [ ] The PDF maps submission data onto the original PDF form fields
-- [ ] All filled fields are legible and correctly positioned
-- [ ] The completed PDF is visually consistent with the original paper form
+- [x] Maya can view a list of submissions for her forms
+- [x] Maya can select a submission and download a completed PDF
+- [x] The PDF maps submission data onto the original PDF form fields
+- [x] All filled fields are legible and correctly positioned
+- [x] The completed PDF is visually consistent with the original paper form
 
 ## Success Metrics:
 
@@ -38,11 +38,12 @@ As a **form creator (Maya)**, in order to **process applications using existing 
 
 ## Definition of Done:
 
-- [ ] Acceptance criteria met
-- [ ] Threat model updated -- any new trust boundaries, data flows, or attack surfaces are reflected in `catalog/architecture/threat-model.md`
-- [ ] Technical documentation updated -- architecture docs and decisions are current
-- [ ] At least one end-to-end test: upload PDF → extract → fill → generate completed PDF
-- [ ] Tests pass
-- [ ] Type checking passes
-- [ ] CI pipeline green
-- [ ] Deployed and demoable
+- [x] Acceptance criteria met
+- [x] Threat model updated -- any new trust boundaries, data flows, or attack surfaces are reflected in `catalog/architecture/threat-model.md`
+- [x] Technical documentation updated -- architecture docs and decisions are current
+- [x] At least one end-to-end test: upload PDF → extract → fill → generate completed PDF
+- [x] Tests pass
+- [x] Type checking passes
+- [x] CI pipeline green
+- [x] Deployed and demoable
+

--- a/catalog/stories/71-developer-navigates-llm-integrations-via-a-screaming-service-layer.md
+++ b/catalog/stories/71-developer-navigates-llm-integrations-via-a-screaming-service-layer.md
@@ -1,0 +1,53 @@
+---
+issue: 71
+title: Developer navigates LLM integrations via a screaming service layer
+milestone: "Final Project"
+labels: [user-story]
+state: closed
+synced_at: 2026-04-20T15:40:03.186Z
+---
+
+## User Story
+
+As a **developer**, in order to **quickly locate every LLM integration point and understand each service's public interface**, I want **the catalog to surface LLM touchpoints explicitly and each service to "scream" its intent through a clear public entrypoint that the catalog can link to on GitHub**.
+
+## Preconditions
+
+- Architecture principles (P1–P4) documented in `catalog/architecture/software-architecture.md`
+- Services currently under `src/services/*` with per-service `types.ts` but no consistent "public API" file
+- Catalog already has architecture, decisions, and experiments sections
+
+## Acceptance Criteria
+
+- [ ] New catalog page (e.g. `catalog/architecture/llm-integrations.md`) enumerates every LLM touchpoint (extraction, shaping, evaluation/judge, conversational filling, future RAG) with deep links to the relevant GitHub source lines
+- [ ] Each service under `src/services/*` has a single, obvious public-interface entrypoint (e.g. `index.ts` re-exports, or a documented convention) so a reader sees the service's intent without scanning every file
+- [ ] The software-architecture doc is updated to describe the "service public interface" convention, reinforcing P1 (intent over mechanism)
+- [ ] Internal helpers are clearly internal: imports from other layers route only through each service's public entrypoint (enforced by `test/architecture/dependency-rule.test.ts` or a sibling test)
+- [ ] Catalog pages that describe a service or experiment link to the service's public entrypoint on GitHub (permalinked to a commit or tag where practical)
+- [ ] A short "how to navigate this codebase" section exists in the catalog (system-overview or a new page) that names the convention and points at the LLM-integrations page as an example
+- [ ] No behavior change: all existing tests and `bun run check` pass
+
+## Success Metrics
+
+- A developer new to the project can list every LLM call site from the catalog in under 5 minutes
+- Service directories read as a list of intents (one entrypoint per service), not a flat pile of files
+- Cross-service imports reference only the public entrypoint of the target service
+
+## Notes
+
+- Framing: this is a "screaming architecture" pass focused on *service public interfaces*, not a rewrite. Prefer moving/renaming and re-exports over refactors.
+- Consider whether the convention is `src/services/<name>/index.ts` (re-exports) or a named file like `src/services/<name>/<name>.ts`. Pick one and document why.
+- Good candidate services to audit first: `forms/` (many files — resolver, session, submission, shaping, filling, etc.), `extraction/`, `evaluation/`, `data-collection/`
+- LLM-integrations catalog page should cross-reference the experiment roadmap (`catalog/experiments/_roadmap.md`) so readers can trace from a variant back to the code that runs it
+- GitHub links should use the `flexion/forms-lab` repo with line ranges; prefer permalinks to `main` unless pinning to a commit is needed
+- Consider adding a dependency-rule test that forbids deep imports across service boundaries once the entrypoint convention is established
+- Start this work after the first round of experiment stories merges to main
+
+## Definition of Done
+
+- [ ] Acceptance criteria met
+- [ ] Threat model updated if security-relevant (unlikely — navigation/docs change)
+- [ ] Tests pass (including dependency-rule tests)
+- [ ] Type checking passes
+- [ ] CI pipeline green
+- [ ] Deployed and demoable (catalog page reachable on the deployed branch)

--- a/catalog/stories/73-maya-s-extractions-use-a-tuned-prompt-prompt-optimization.md
+++ b/catalog/stories/73-maya-s-extractions-use-a-tuned-prompt-prompt-optimization.md
@@ -1,0 +1,35 @@
+---
+issue: 73
+title: Maya's extractions use a tuned prompt (prompt optimization)
+milestone: ""
+labels: [user-story, llm-integration]
+state: closed
+synced_at: 2026-04-20T15:40:03.186Z
+---
+
+## User Story
+
+As **Maya**, in order to **get better extraction quality by applying the prompt engineering techniques proven in the coursework**, I want **extraction prompt variants optimized using the hybrid and few-shot strategies from Assignment 10**.
+
+## Context
+
+Assignment 10 showed:
+- Hybrid prompt (concise instructions + 1 example) achieved 98-100% on Mistral 8B
+- Temperature tuning (0.2 → 0.0) eliminated 1% failure variance at zero cost
+- TextGrad automated optimization produced worse results than hand-crafted prompts
+
+This story applies those findings to the extraction pipeline specifically: test temperature=0, test a hybrid-style extraction prompt, and measure with the existing eval harness.
+
+## Acceptance Criteria
+
+- [ ] Temperature=0 variant registered and evaluated (measures the "free optimization" from homework)
+- [ ] Hybrid-style extraction prompt tested (shorter instructions + 1 complete example extraction)
+- [ ] Evaluation results with LLM judge scorer on all 3 fixtures
+- [ ] Catalog page with findings, course connection, and comparison to baseline
+- [ ] Roadmap updated
+
+## Definition of Done
+
+- [ ] Tests pass (`bun run check`)
+- [ ] Evaluation complete
+- [ ] Catalog page with documented findings

--- a/catalog/stories/74-maya-s-extractions-cite-the-law-rag.md
+++ b/catalog/stories/74-maya-s-extractions-cite-the-law-rag.md
@@ -1,0 +1,31 @@
+---
+issue: 74
+title: Maya's extractions cite the law (RAG)
+milestone: ""
+labels: [user-story, llm-integration]
+state: closed
+synced_at: 2026-04-20T15:40:03.186Z
+---
+
+## User Story
+
+As **Maya**, in order to **get extractions that reference relevant regulations and form instructions**, I want **an extraction variant that retrieves policy context via RAG before extracting fields**.
+
+## Context
+
+The homework repo has a working ChromaDB + sentence-transformers RAG implementation. This story brings retrieval-augmented generation into the extraction pipeline: embed form instructions/CFR sections, retrieve relevant context for the uploaded PDF, and include it in the extraction prompt.
+
+## Acceptance Criteria
+
+- [ ] RAG retrieval primitive (embeddings + vector store) integrated
+- [ ] Policy corpus seeded (form instructions for the 3 evaluation fixtures)
+- [ ] New variant `extraction/sonnet-with-rag` registered
+- [ ] Evaluation run comparing RAG variant against baseline Sonnet
+- [ ] Catalog page with findings and course connection
+- [ ] Roadmap updated
+
+## Definition of Done
+
+- [ ] Tests pass (`bun run check`)
+- [ ] Evaluation complete with LLM judge
+- [ ] Catalog page documents approach, metrics, and course connection

--- a/catalog/stories/75-run-live-shaping-model-evaluation.md
+++ b/catalog/stories/75-run-live-shaping-model-evaluation.md
@@ -1,0 +1,31 @@
+---
+issue: 75
+title: Run live shaping model evaluation
+milestone: ""
+labels: [user-story, llm-integration]
+state: closed
+synced_at: 2026-04-20T15:40:03.186Z
+---
+
+## User Story
+
+As **Maya**, in order to **see quantitative benchmarks for the shaping model variants**, I want **a CLI runner that evaluates all three shaping models against the scripted intent suite**.
+
+## Context
+
+Story #59 shipped the `shaping-commands` evaluation kind and 6 scripted intents with expected outputs. The scoring logic is tested. What's missing is a CLI command to actually call each model with the intents and record results.
+
+## Acceptance Criteria
+
+- [ ] CLI command: `bun run cli evaluate shaping run <variant-id>`
+- [ ] Runs all 6 scripted intents against the selected shaping variant
+- [ ] Writes results to `catalog/experiments/shaping-model-comparison/{variant}.json`
+- [ ] Generates markdown catalog page with metrics
+- [ ] All three variants evaluated: bedrock-haiku, bedrock-sonnet, bedrock-opus
+- [ ] Catalog pages updated with real metrics
+
+## Definition of Done
+
+- [ ] Tests pass
+- [ ] All three variants evaluated
+- [ ] Catalog pages populated

--- a/catalog/stories/8-maya-refines-the-data-model-with-llm-assistance.md
+++ b/catalog/stories/8-maya-refines-the-data-model-with-llm-assistance.md
@@ -4,7 +4,7 @@ title: Maya refines the data model with LLM assistance
 milestone: "Final Project"
 labels: [user-story, llm-integration]
 state: open
-synced_at: 2026-04-09T14:40:12.308Z
+synced_at: 2026-04-20T15:40:03.188Z
 ---
 
 ## User Story:

--- a/catalog/stories/87-maya-authors-a-snap-form-guided-by-policy-corpus-and-auto-evaluation.md
+++ b/catalog/stories/87-maya-authors-a-snap-form-guided-by-policy-corpus-and-auto-evaluation.md
@@ -1,0 +1,64 @@
+---
+issue: 87
+title: Maya authors a SNAP form guided by policy corpus and auto-evaluation
+milestone: "Final Project"
+labels: [user-story]
+state: closed
+synced_at: 2026-04-20T15:40:03.186Z
+---
+
+## User Story
+
+As a **form creator (Maya)**, in order to **build a compliant SNAP application grounded in federal and state policy without memorizing regulations**, I want **an agent-guided pipeline that reads my policy corpus, proposes evaluation criteria, generates form structure and fields with regulatory citations, and auto-evaluates its output before I review it**
+
+## Preconditions
+
+- [ ] Existing shaping command infrastructure (24 commands, executor, staged-changes UI)
+- [ ] RAG service with corpus loader, embeddings, and in-memory retrieval
+- [ ] Project git repo with `references/` directory support
+- [ ] Bedrock access for Sonnet and Haiku models
+
+## Acceptance Criteria
+
+- [ ] SNAP Wisconsin policy corpus (~10-15 chunks from 7 CFR 273) available as fixture in `catalog/references/snap-wisconsin.md`
+- [ ] SNAP Wisconsin test fixture in `fixtures/snap-wisconsin/` with manifest, ground-truth, and source PDF
+- [ ] Corpus loader supports project-scoped `references/*.md` via `projectDir` option
+- [ ] Stage 1: Agent analyzes corpus and proposes evaluation criteria as English sentences with regulatory citations
+- [ ] Stage 1: Human can review, edit, add, remove, and approve criteria via UI
+- [ ] Stage 2: Agent proposes page/group skeleton as shaping commands grounded in approved criteria and corpus
+- [ ] Stage 2: Human reviews commands in staged-changes UI, can accept/reject/redirect via chat
+- [ ] Stage 3: Agent generates fields per section with topic-scoped RAG retrieval (~5-15 commands per group)
+- [ ] Stage 4: LLM-as-judge evaluates each section against approved criteria (pass/fail/partial)
+- [ ] Stage 4: Failed criteria trigger automatic retry with specific feedback (max 2 retries)
+- [ ] Eval scorecard displayed alongside staged commands before human review
+- [ ] Pipeline artifacts persisted in git: `criteria.json`, `eval-results.json`
+- [ ] Per-stage model configuration (Sonnet for stages 1-3, Haiku for eval)
+- [ ] Stage indicator in project UI showing pipeline progress
+- [ ] Existing reactive shaping chat continues to work at any pipeline stage
+
+## Success Metrics
+
+- Pipeline produces a complete SNAP form (6+ pages, 10+ groups, 50+ fields) from corpus alone
+- Auto-eval catches at least one missing regulatory requirement per run and self-corrects via retry
+- Policy expert (persona A) can skip stages and shape manually without friction
+- Form output usable as test fixture by existing evaluation harness
+
+## Notes
+
+- Design spec: `notes/2026-04-19-rag-authoring-pipeline-design.md`
+- New service at `src/services/form-authoring/` — does not modify existing shaper
+- When source PDF is provided (Stage 0), existing extraction pipeline bootstraps initial state
+- Corpus upload UI is deferred — corpus pre-loaded as fixtures for now
+- Repeating groups (household members) modeled as static Member 1/2/3 — known limitation
+- Fallback scope: cut auto-eval inner loop if time-constrained; criteria still generated and reviewed
+- Temperature 0 across all stages for determinism
+- Estimated ~25 Bedrock calls for a full SNAP form run (~3-5 min wall clock)
+
+## Definition of Done
+
+- [ ] Acceptance criteria met
+- [ ] Threat model updated if security-relevant
+- [ ] Tests pass
+- [ ] Type checking passes
+- [ ] CI pipeline green
+- [ ] Deployed and demoable

--- a/catalog/stories/9-carlos-completes-complex-sections-through-conversation.md
+++ b/catalog/stories/9-carlos-completes-complex-sections-through-conversation.md
@@ -4,7 +4,7 @@ title: Carlos completes complex sections through conversation
 milestone: "Final Project"
 labels: [user-story, llm-integration]
 state: open
-synced_at: 2026-04-09T14:40:12.308Z
+synced_at: 2026-04-20T15:40:03.188Z
 ---
 
 ## User Story:

--- a/catalog/walkthrough/09-whats-next.md
+++ b/catalog/walkthrough/09-whats-next.md
@@ -15,7 +15,6 @@ Forms Lab demonstrates the foundation. Here's where it goes from here:
 - **Conversational form filling** — Carlos completes complex sections through dialogue with an LLM agent (Story #9)
 - **LLM-assisted refinement** — Maya uses conversation to iteratively improve the data model (Story #8)
 - **Advanced evaluation** — LLM-as-Judge scoring for richer, semantic evaluation of extraction quality
-- **PDF generation** — Complete the round-trip: PDF in, web form, PDF out with filled data (Story #7)
 
 ## Open Questions
 

--- a/notes/flight-board.md
+++ b/notes/flight-board.md
@@ -6,7 +6,6 @@
 |-------|--------|--------|----------|---------|
 | #9 Carlos completes complex sections through conversation | story-9/conversational-sections | in-progress | .worktrees/story-9-conversational-sections | 2026-04-18 |
 | #9 UX fixes (live field updates, loading, context) | story-9/ux-fixes | pr-open ([#83](https://github.com/flexion/forms-lab/pull/83)) | main repo checkout | 2026-04-19 |
-| #87 Maya authors SNAP form guided by policy corpus | story-87/rag-authoring-pipeline | pr-open ([#88](https://github.com/flexion/forms-lab/pull/88)) | .worktrees/story-87-rag-authoring-pipeline | 2026-04-20 |
 
 ## Landed
 
@@ -14,6 +13,7 @@ Most recent first.
 
 | Story | Branch | Status | PR | Merged |
 |-------|--------|--------|----|--------|
+| #87 Maya authors SNAP form guided by policy corpus | story-87/rag-authoring-pipeline | shipped | [#88](https://github.com/flexion/forms-lab/pull/88) | 2026-04-20 |
 | #71 Developer navigates LLM integrations via a screaming service layer | story-71/llm-integrations-catalog | shipped | [#84](https://github.com/flexion/forms-lab/pull/84) | 2026-04-19 |
 | #74 Maya's extractions cite the law (RAG) | experiment/74-rag-extraction | shipped | [#78](https://github.com/flexion/forms-lab/pull/78) | 2026-04-19 |
 | #75 Run live shaping model evaluation | experiment/75-shaping-eval | shipped | [#77](https://github.com/flexion/forms-lab/pull/77) | 2026-04-19 |


### PR DESCRIPTION
## Context

Story close-out pass on 2026-04-20. Several user-story issues on GitHub were still OPEN despite their PRs having merged, and `catalog/stories/` was missing ~13 story files entirely.

## Changes

**Story state:**
- #7 *Maya receives a completed PDF* — closed on GitHub with AC + DoD ticked (shipped in PR #22 on 2026-04-19).

**Catalog sync:**
- `bun run cli sync-stories` refreshed `catalog/stories/` from GitHub Issues.
- 13 previously-unsynced stories now land locally (#59, #60, #61, #62, #63, #64, #65, #66, #71, #73, #74, #75, #87).
- 11 existing files pick up state updates (mostly `open` → `closed` and body edits made on GitHub).

**Docs reconciliation:**
- `notes/flight-board.md`: move #87 from In Flight to Landed (PR #88 merged 2026-04-20).
- `catalog/walkthrough/09-whats-next.md`: drop the "PDF generation (Story #7)" bullet from Planned Capabilities now that the round-trip is shipped.

## Out of scope

- **#9** (Carlos conversational): main feature shipped in PR #72 but UX follow-up PR #83 is still open — keeping issue open per session decision.
- **#64** (tuned prompt): already documented as scope-deferred in `catalog/experiments/_roadmap.md`; issue intentionally left open.
- Genuine backlog (#8, #52, #60, #61, #65) untouched.

## Testing

- [x] `bun run check` passes (1322 tests)
- [x] `bun run cli sync-stories` round-trips cleanly