### PR TITLE
fix(extraction): emit choices for choice fields, prefer radio over boolean (#56)

### DIFF
--- a/src/services/form-documents/extraction-tools.ts
+++ b/src/services/form-documents/extraction-tools.ts
@@ -38,7 +38,8 @@ export const extractionTools = {
     execute: async ({ id }) => `Group "${id}" added.`,
   }),
   addField: tool({
-    description: 'Add a field (requirement) to the most recently added group.',
+    description:
+      'Add a field (requirement) to the most recently added group. For yes/no questions, pass fieldType "choice" with choices ["Yes","No"] rather than boolean. Reserve boolean for agreement checkboxes.',
     inputSchema: z.object({
       id: z.string().describe('kebab-case field ID'),
       fieldName: z.string().describe('camelCase field name'),
@@ -46,6 +47,12 @@ export const extractionTools = {
       fieldType: fieldType,
       required: z.boolean(),
       helpText: z.string().optional(),
+      choices: z
+        .array(z.string())
+        .optional()
+        .describe(
+          'Required when fieldType is "choice" (e.g. ["Yes","No"] or ["Single","Married","Other"]). Omit for other field types.',
+        ),
       sensitivity: sensitivity.optional(),
     }),
     execute: async ({ id }) => `Field "${id}" added.`,
@@ -139,6 +146,7 @@ export function reconstructSpec(
           fieldType: string
           required: boolean
           helpText?: string
+          choices?: string[]
           sensitivity?: string
         }
         spec.groups[currentGroupIndex].requirements.push({
@@ -149,6 +157,7 @@ export function reconstructSpec(
             input.fieldType as DataCollectionSpec['groups'][0]['requirements'][0]['fieldType'],
           required: input.required,
           helpText: input.helpText,
+          choices: input.choices,
           sensitivity: input.sensitivity as
             | 'low'
             | 'medium'

--- a/src/services/form-documents/extraction.ts
+++ b/src/services/form-documents/extraction.ts
@@ -236,6 +236,7 @@ export function createBedrockPdfExtractor(
             "fieldType": "text|email|phone|url|number|currency|date|boolean|choice|longText",
             "required": true/false,
             "helpText": "string (optional)",
+            "choices": ["string"] (required for fieldType "choice", otherwise omit),
             "sensitivity": "low|medium|high|pii (optional)"
           }
         ]
@@ -254,6 +255,8 @@ export function createBedrockPdfExtractor(
 ${exemplarSection}Guidelines:
 - Group related fields (e.g., "Personal Information", "Employment History")
 - Use kebab-case for ids, camelCase for fieldName
+- For yes/no questions, use fieldType "choice" with choices ["Yes", "No"] rather than boolean. Reserve boolean for agreement checkboxes (e.g., "I agree to the terms").
+- Every "choice" field MUST include a non-empty \`choices\` array listing the options (e.g., ["US Citizen", "Permanent Resident", "Other"]).
 - Flag low-confidence fields (< 0.8) with descriptive flags
 - Only include validation rules and conditions if clearly specified in the form
 - Be thorough — extract every field visible in the form`

--- a/src/services/form-documents/hybrid-extraction-prompt.ts
+++ b/src/services/form-documents/hybrid-extraction-prompt.ts
@@ -56,6 +56,7 @@ ${formattedOutput}
             "fieldType": "text|email|phone|url|number|currency|date|boolean|choice|longText",
             "required": true/false,
             "helpText": "string (optional)",
+            "choices": ["string"] (required for fieldType "choice", otherwise omit),
             "sensitivity": "low|medium|high|pii (optional)"
           }
         ]
@@ -73,5 +74,5 @@ ${formattedOutput}
 
 ## Your extraction
 
-Return ONLY the JSON. Use kebab-case ids, camelCase fieldNames. Flag fields you're less than 80% confident on. Be thorough.`
+Return ONLY the JSON. Use kebab-case ids, camelCase fieldNames. Flag fields you're less than 80% confident on. Be thorough. For yes/no questions use fieldType "choice" with choices ["Yes", "No"] (reserve boolean for agreement checkboxes). Every "choice" field MUST include a non-empty \`choices\` array.`
 }

--- a/src/services/form-documents/schemas.ts
+++ b/src/services/form-documents/schemas.ts
@@ -18,28 +18,38 @@ export const fieldConfidenceSchema = z.object({
   flags: z.array(z.string()).optional(),
 })
 
-export const dataRequirementSchema = z.object({
-  id: z.string(),
-  fieldName: z.string(),
-  label: z.string(),
-  fieldType: z.enum([
-    'text',
-    'email',
-    'phone',
-    'url',
-    'number',
-    'currency',
-    'date',
-    'boolean',
-    'choice',
-    'longText',
-  ]),
-  required: z.boolean(),
-  helpText: z.string().optional(),
-  validation: z.array(validationRuleSchema).optional(),
-  condition: conditionSchema.optional(),
-  sensitivity: z.enum(['low', 'medium', 'high', 'pii']).optional(),
-})
+export const dataRequirementSchema = z
+  .object({
+    id: z.string(),
+    fieldName: z.string(),
+    label: z.string(),
+    fieldType: z.enum([
+      'text',
+      'email',
+      'phone',
+      'url',
+      'number',
+      'currency',
+      'date',
+      'boolean',
+      'choice',
+      'longText',
+    ]),
+    required: z.boolean(),
+    helpText: z.string().optional(),
+    choices: z.array(z.string()).optional(),
+    validation: z.array(validationRuleSchema).optional(),
+    condition: conditionSchema.optional(),
+    sensitivity: z.enum(['low', 'medium', 'high', 'pii']).optional(),
+  })
+  .refine(
+    (r) => r.fieldType !== 'choice' || (r.choices && r.choices.length > 0),
+    {
+      message:
+        'choice fields must include a non-empty `choices` array (e.g. ["Yes", "No"] for yes/no questions)',
+      path: ['choices'],
+    },
+  )
 
 export const requirementGroupSchema = z.object({
   id: z.string(),

--- a/test/form-documents/extraction-schema.test.ts
+++ b/test/form-documents/extraction-schema.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  dataRequirementSchema,
+  extractionResponseSchema,
+} from '../../src/services/form-documents/schemas'
+
+describe('dataRequirementSchema', () => {
+  it('accepts a text field without choices', () => {
+    const parsed = dataRequirementSchema.safeParse({
+      id: 'first-name',
+      fieldName: 'firstName',
+      label: 'First name',
+      fieldType: 'text',
+      required: true,
+    })
+    expect(parsed.success).toBe(true)
+  })
+
+  it('accepts a choice field with choices', () => {
+    const parsed = dataRequirementSchema.safeParse({
+      id: 'prior-application',
+      fieldName: 'priorApplication',
+      label: 'Have you applied before?',
+      fieldType: 'choice',
+      required: true,
+      choices: ['Yes', 'No'],
+    })
+    expect(parsed.success).toBe(true)
+  })
+
+  it('rejects a choice field without choices', () => {
+    const parsed = dataRequirementSchema.safeParse({
+      id: 'prior-application',
+      fieldName: 'priorApplication',
+      label: 'Have you applied before?',
+      fieldType: 'choice',
+      required: true,
+    })
+    expect(parsed.success).toBe(false)
+    if (!parsed.success) {
+      expect(parsed.error.issues[0].path).toContain('choices')
+    }
+  })
+
+  it('rejects a choice field with an empty choices array', () => {
+    const parsed = dataRequirementSchema.safeParse({
+      id: 'status',
+      fieldName: 'status',
+      label: 'Status',
+      fieldType: 'choice',
+      required: true,
+      choices: [],
+    })
+    expect(parsed.success).toBe(false)
+  })
+
+  it('accepts a boolean agreement field (no choices expected)', () => {
+    const parsed = dataRequirementSchema.safeParse({
+      id: 'agree-terms',
+      fieldName: 'agreeTerms',
+      label: 'I agree to the terms',
+      fieldType: 'boolean',
+      required: true,
+    })
+    expect(parsed.success).toBe(true)
+  })
+})
+
+describe('extractionResponseSchema', () => {
+  it('surfaces choice-field validation errors through the full response', () => {
+    const parsed = extractionResponseSchema.safeParse({
+      spec: {
+        id: 'demo',
+        title: 'Demo',
+        description: 'd',
+        groups: [
+          {
+            id: 'g',
+            title: 'G',
+            requirements: [
+              {
+                id: 'f',
+                fieldName: 'f',
+                label: 'F',
+                fieldType: 'choice',
+                required: true,
+                // intentionally missing choices
+              },
+            ],
+          },
+        ],
+      },
+    })
+    expect(parsed.success).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #56.

## Context

The extraction prompts didn't include \`choices\` in the schema example, so choice fields arrived with no options and rendered as nothing. Yes/no questions were extracted as \`boolean\` (single checkbox) rather than \`choice\` with \`["Yes", "No"]\` (radio pair), which is worse UX.

Observed on the Federal Pardon form — "Citizenship" and "previous application" fields both broken.

## Changes

- **Baseline + hybrid Step-1 prompts** — add \`choices\` to the schema example with a "required for choice" annotation; tell the model to use \`choice\` for yes/no questions and reserve \`boolean\` for agreement checkboxes
- **Zod schema** — \`choices\` is optional in general, but refined to require a non-empty array when \`fieldType === 'choice'\`
- **Tool-use variant** — match the same shape: tool input schema gains \`choices\`, reconstructor passes it through
- **Tests** — new \`test/form-documents/extraction-schema.test.ts\` pins the refinement so it can't regress silently

## Testing

- [x] \`bun run check\` — 1329 tests pass, lint + type clean
- [ ] Deploy and re-extract the Pardon form, verify citizenship renders as a control and the yes/no question renders as a radio pair

## Related

- Issue: #56
- Runtime check: the form renderer already no-ops on choice fields missing \`choices\`; the schema refinement promotes this from a silent render failure to a validated contract.