### PR TITLE
fix(owner): reconcile empty-state CTAs and drop 404 for unknown users

### DIFF
--- a/src/entrypoints/app/routes/owner/components.tsx
+++ b/src/entrypoints/app/routes/owner/components.tsx
@@ -55,7 +55,7 @@ export const ProfilePage: FC<{
       <section class="l-stack">
         <div class="l-cluster justify-between" style="align-items: baseline;">
           <h2>Projects</h2>
-          {isOwnProfile && (
+          {isOwnProfile && projects.length > 0 && (
             <a href={resolveUrl('/new')} class="flex-button">
               New Project
             </a>
@@ -1036,9 +1036,11 @@ export const Dashboard: FC<{
       <section class="l-stack">
         <div class="l-cluster justify-between" style="align-items: baseline;">
           <h2>Recent projects</h2>
-          <a href={resolveUrl('/new')} class="flex-button">
-            New Project
-          </a>
+          {recentProjects.length > 0 && (
+            <a href={resolveUrl('/new')} class="flex-button">
+              New Project
+            </a>
+          )}
         </div>
         {recentProjects.length === 0 ? (
           <div class="l-stack">

--- a/src/entrypoints/app/routes/owner/index.tsx
+++ b/src/entrypoints/app/routes/owner/index.tsx
@@ -44,15 +44,11 @@ export function createOwnerRoutes(
     const projects = service.listUserProjects(owner)
     const profile = userStore.get(owner)
 
-    if (!profile && projects.length === 0) {
-      return c.html(
-        <Layout user={c.get('user')}>
-          <ErrorPage statusCode={404} message="User not found" />
-        </Layout>,
-        404,
-      )
-    }
-
+    // Profile records are stored per deployment (each branch app has its
+    // own SQLite), so a user who has only signed in on a different branch
+    // won't have a record here. Rather than 404 on a valid-looking
+    // username — which breaks shareable profile URLs across branches —
+    // fall back to a minimal profile using the login as the display name.
     const displayProfile = profile ?? {
       login: owner,
       name: owner,

--- a/test/owner-routes.test.ts
+++ b/test/owner-routes.test.ts
@@ -171,20 +171,39 @@ describe('GET /:owner (profile)', () => {
     expect(html).toContain('No projects yet')
   })
 
-  it('returns 404 for nonexistent user', async () => {
+  it('returns a friendly empty profile for unknown usernames', async () => {
+    // Profile records are per-deployment; showing 404 for a username
+    // that exists on another branch but not this one breaks shareable
+    // URLs. Fall back to a minimal profile view instead.
     const { app } = createTestApp()
     const res = await app.request('/nonexistent')
-    expect(res.status).toBe(404)
+    expect(res.status).toBe(200)
     const html = await res.text()
-    expect(html).toContain('User not found')
+    expect(html).toContain('nonexistent')
+    expect(html).toContain('No projects yet')
+    expect(html).not.toContain('User not found')
   })
 
-  it('shows New Project button when viewing own profile', async () => {
+  it('shows New Project button on own profile only when projects exist', async () => {
     const { app } = createTestApp(danielUser)
     const res = await app.request('/danielnaab')
     expect(res.status).toBe(200)
     const html = await res.text()
-    expect(html).toContain('New Project')
+    // Empty state: header button hidden, inline CTA shown instead.
+    expect(html).not.toMatch(
+      /<a[^>]*class="flex-button"[^>]*>\s*New Project\s*</,
+    )
+    expect(html).toContain('Create your first project')
+  })
+
+  it('shows header New Project button when own profile has projects', async () => {
+    const { app, service, projectStore } = createTestApp(danielUser)
+    await createReadyProject(service, projectStore)
+    const res = await app.request('/danielnaab')
+    expect(res.status).toBe(200)
+    const html = await res.text()
+    expect(html).toMatch(/<a[^>]*class="flex-button"[^>]*>\s*New Project\s*</)
+    expect(html).not.toContain('Create your first project')
   })
 
   it('hides New Project button when viewing another user profile', async () => {


### PR DESCRIPTION
Two small polish fixes on the owner/profile routes.

## 1. Duplicate empty-state CTAs

The Dashboard and ProfilePage both rendered a "New Project" button in the section header *and* a "Create your first project" button inline. For a signed-in user with no projects, that's the same action twice, which makes the page look overpopulated with nothing to do.

**Fix:** hide the header "New Project" button when the list is empty, keep the inline CTA. Once the user has projects, the header button takes over and the inline prompt is gone.

## 2. 404 User not found on shareable profile URLs

\`/main/danielnaab\` on production returned 404 because main's \`userStore\` (per-branch SQLite) had no record — the user had only signed in on a dev branch. That breaks shareable profile URLs across deployments.

**Fix:** drop the 404. Render the profile page with the login as the display name when there's no stored record. If the profile also has no projects, the inline "No projects yet" copy covers it. This matches how we already handle profiles whose commits reference a login whose display row isn't populated.

## Testing

- [x] \`bun run check\` — 1330 tests pass, including new/updated assertions on owner routes