### PR TITLE
docs(presentation): correct Key Findings numbers

### DIFF
--- a/src/entrypoints/app/routes/presentation/index.tsx
+++ b/src/entrypoints/app/routes/presentation/index.tsx
@@ -291,7 +291,7 @@ presentation.get('/', (c) => {
             <div class="grid-2x2">
               <div class="cell">
                 <h3>Extraction</h3>
-                <p>PDF &rarr; structured fields, 10 variants</p>
+                <p>PDF &rarr; structured fields, 9 variants</p>
               </div>
               <div class="cell">
                 <h3>Shaping</h3>
@@ -343,38 +343,39 @@ presentation.get('/', (c) => {
               <tbody>
                 <tr>
                   <td>Sonnet baseline</td>
-                  <td>55%</td>
-                  <td>87%</td>
-                  <td>45%</td>
+                  <td>62%</td>
+                  <td>79%</td>
+                  <td>27%</td>
                 </tr>
                 <tr>
-                  <td>Few-shot</td>
+                  <td>Few-shot (3 exemplars)</td>
                   <td>55%</td>
                   <td>87%</td>
-                  <td>51%</td>
+                  <td>21%</td>
                 </tr>
                 <tr>
                   <td>Tool-use</td>
-                  <td>44%</td>
+                  <td>35%</td>
                   <td>96%</td>
-                  <td>96%</td>
+                  <td>79%</td>
                 </tr>
                 <tr class="highlight">
-                  <td>Hybrid v1</td>
+                  <td>Hybrid v1 (1 exemplar, temp=0)</td>
                   <td>73%</td>
                   <td>99%</td>
-                  <td>96%</td>
+                  <td>51%</td>
                 </tr>
                 <tr>
                   <td>RAG-grounded</td>
-                  <td>55%</td>
-                  <td>87%</td>
-                  <td>70%</td>
+                  <td>56%</td>
+                  <td>93%</td>
+                  <td>53%</td>
                 </tr>
               </tbody>
             </table>
             <p class="table-footer">
-              "Prompt shape matters more than few-shot examples"
+              "One exemplar beats three. Prompt shape matters more than
+              example count."
             </p>
           </section>
 


### PR DESCRIPTION
Slide 7 had drifted from the catalog write-ups. All five rows were at least partly wrong on sensitivity, and most were wrong on recall/precision as well.

## Corrected numbers

| Variant | Recall | Precision | Sensitivity | Source |
|---|---|---|---|---|
| Sonnet baseline | 62 % | 79 % | 27 % | \`catalog/…/sonnet.md\` |
| Few-shot (3 ex.) | 55 % | 87 % | 21 % | \`catalog/…/few-shot-sonnet.md\` |
| Tool-use | 35 % | 96 % | 79 % | \`catalog/…/tool-use-sonnet.md\` |
| **Hybrid v1** | **73 %** | **99 %** | **51 %** | \`catalog/…/sonnet-hybrid-v1.md\` |
| RAG-grounded | 56 % | 93 % | 53 % | \`catalog/…/sonnet-with-rag.md\` |

Also refreshes the footer to the actual story ("one exemplar beats three") and updates slide 5's "10 variants" to the current count (9).

## Testing

- [x] \`bun run check\` — 1330 tests pass
- [ ] Eyeball /presentation and confirm the table renders and hybrid-v1 row still highlights