### PR TITLE
fix(design-system): add missing stylesheets for chat-panel and variant-badge

### DIFF
--- a/src/design-system/components/flex-chat-panel/styles.css
+++ b/src/design-system/components/flex-chat-panel/styles.css
@@ -1,0 +1,77 @@
+/**
+ * flex-chat-panel — conversational message transcript + input form.
+ *
+ * Used by the conversational form delivery mode. Wraps a scrolling
+ * message stream with a persistent composer, and swaps the composer
+ * for a completion notice once the session ends.
+ */
+
+@layer block {
+  .flex-chat-panel {
+    display: flex;
+    flex-direction: column;
+    gap: var(--flex-space-md);
+    padding: var(--flex-space-md);
+    border: 1px solid var(--flex-color-border);
+    border-radius: var(--flex-radius-md);
+    background: var(--flex-color-surface);
+  }
+
+  .flex-chat-panel__messages {
+    display: flex;
+    flex-direction: column;
+    gap: var(--flex-space-sm);
+    max-height: 60vh;
+    overflow-y: auto;
+  }
+
+  .flex-chat-panel__message {
+    display: flex;
+    padding: var(--flex-space-sm) var(--flex-space-md);
+    border-radius: var(--flex-radius-md);
+    max-width: 85%;
+    line-height: 1.5;
+  }
+
+  .flex-chat-panel__message[data-role='user'] {
+    align-self: flex-end;
+    background: var(--flex-color-primary-lighter);
+    color: var(--flex-color-primary-darker);
+  }
+
+  .flex-chat-panel__message[data-role='assistant'] {
+    align-self: flex-start;
+    background: var(--flex-color-base-lightest);
+    color: var(--flex-color-base-darker);
+  }
+
+  .flex-chat-panel__message-content {
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+  }
+
+  .flex-chat-panel__form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--flex-space-sm);
+    padding-block-start: var(--flex-space-sm);
+    border-block-start: 1px solid var(--flex-color-border);
+  }
+
+  .flex-chat-panel__input-group {
+    display: flex;
+  }
+
+  .flex-chat-panel__actions {
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  .flex-chat-panel__finished {
+    padding: var(--flex-space-sm) var(--flex-space-md);
+    border-radius: var(--flex-radius-md);
+    background: var(--flex-color-success-lighter);
+    color: var(--flex-color-success-darker);
+    text-align: center;
+  }
+}

--- a/src/design-system/components/flex-variant-badge/styles.css
+++ b/src/design-system/components/flex-variant-badge/styles.css
@@ -1,0 +1,49 @@
+/**
+ * flex-variant-badge — inline provenance badge for LLM-produced content.
+ *
+ * Tells the viewer which variant produced what they're looking at
+ * (e.g. "Extracted by Claude Sonnet 4 (hybrid prompt)") with a link
+ * back to the variant picker.
+ */
+
+@layer block {
+  .variant-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--flex-space-2xs);
+    padding: var(--flex-space-2xs) var(--flex-space-sm);
+    font-size: var(--flex-text-sm);
+    line-height: 1.4;
+    color: var(--flex-color-base-darker);
+    background: var(--flex-color-base-lightest);
+    border: 1px solid var(--flex-color-border);
+    border-radius: var(--flex-radius-pill);
+  }
+
+  .variant-badge a {
+    color: inherit;
+    text-decoration: underline;
+    text-decoration-style: dotted;
+  }
+
+  .variant-badge a:hover,
+  .variant-badge a:focus {
+    text-decoration-style: solid;
+  }
+
+  /* Per-task accent so viewers can visually distinguish which stage
+   * produced the content (extraction vs shaping vs filling, etc.).
+   * Falls through to the default surface tint when data-task is
+   * missing. */
+  .variant-badge[data-task='extraction'] {
+    background: var(--flex-color-primary-lighter);
+  }
+
+  .variant-badge[data-task='shaping'] {
+    background: var(--flex-color-accent-warm-lighter);
+  }
+
+  .variant-badge[data-task='filling'] {
+    background: var(--flex-color-accent-cool-lighter);
+  }
+}

--- a/src/entrypoints/app/public/styles.css
+++ b/src/entrypoints/app/public/styles.css
@@ -91,6 +91,8 @@
 @import "../../../design-system/components/flex-spec-diff-browser/styles.css" layer(block);
 @import "../../../design-system/components/flex-pipeline-panel/styles.css" layer(block);
 @import "../../../design-system/components/flex-sidebar-tabs/styles.css" layer(block);
+@import "../../../design-system/components/flex-chat-panel/styles.css" layer(block);
+@import "../../../design-system/components/flex-variant-badge/styles.css" layer(block);
 @import "../routes/projects/styles.css" layer(block);
 @import "../routes/owner/edit/styles.css" layer(block);
 @import "../routes/owner/edit/editor-layout.css" layer(block);


### PR DESCRIPTION
Audit triggered by: "do all the design system components include their source CSS 'View stylesheet' links, if appropriate?"

## Findings

Of 82 \`src/design-system/components/*\`, 74 have a \`styles.css\`. Of the 8 without one, **two were genuinely broken**:

| Component | Classes declared | CSS defined | Status |
|---|---|---|---|
| flex-chat-panel | \`.flex-chat-panel\`, \`.flex-chat-panel__message\`, … (BEM) | nowhere | **broken** |
| flex-variant-badge | \`.variant-badge\`, \`[data-task=…]\` | nowhere | **broken** |
| flex-catalog-sidebar | none | n/a | fine |
| flex-form-confirmation | uses \`.flex-summary-list\` from flex-form-review | re-used | fine |
| flex-form-field, flex-form-landing, flex-form-page, flex-tag-list | base-class only | re-used | fine |

The first two were effectively unstyled at runtime. The other six deliberately re-use styling from base classes and other components.

## Changes

- Add \`flex-chat-panel/styles.css\` — message stream with per-role alignment and a composer/finished swap
- Add \`flex-variant-badge/styles.css\` — pill badge with a per-task accent (extraction/shaping/filling)
- Wire both into \`public/styles.css\` cascade layer

Both stylesheets use \`--flex-*\` design tokens exclusively (passes stylelint's token-enforcement rule).

## Side effect

Both component pages in \`/catalog/design-system/\` now surface the "Source CSS → View stylesheet" section, matching the 74 other components.

## Testing

- [x] \`bun run check\` — 1330 tests pass
- [x] \`bun run lint:css\` — my two new files are clean
- [x] \`bun run build:css\` — cascade imports resolve
- [ ] Eyeball the catalog pages after deploy