### PR TITLE
fix(shaping): make multi-step conversational edits work reliably

### DIFF
--- a/notes/2026-04-20-conversational-edit-multistep/design.md
+++ b/notes/2026-04-20-conversational-edit-multistep/design.md
@@ -1,0 +1,76 @@
+---
+status: working
+date: 2026-04-20
+topic: fix conversational edit failures on multi-step command sequences
+---
+
+# Conversational edit: make multi-step sequences work
+
+## Problem
+
+Running a conversational edit like `'add a new "confirmation" page at the end with a checkbox'` surfaces:
+
+> `Error: LLM produced invalid command sequence: Unknown field id: confirmation-group_field_0 (command 3)`
+
+The LLM emits a 4-command sequence (`addPage` → `addGroup` → `addField` → `setFieldControl`) and invents an id for a field it didn't explicitly create, so the sequential validator in `executor.ts:592` rejects the last command.
+
+## Root causes
+
+1. The shaper prompt (`bedrock-shaper.ts:58-62`) doesn't teach the LLM the multi-step id pattern: provide an explicit `id` to creation tools you plan to reference, then reuse that exact id. Tool descriptions hint at it but the prompt itself is vague.
+2. The shaper throws on the first validation failure — no retry with error feedback. The `previousAttempt` plumbing already exists on `ShapingRequest` but is only used by the client-side retry UX.
+3. The LLM over-commands: `boolean` already renders as a checkbox, so `setFieldControl` is redundant — but nothing tells the LLM that, and `addField` has no `control` / `helpText` shortcut so complex fields require 2+ commands.
+4. "Unknown field id" errors don't list the ids that DO exist, so neither the LLM on retry nor a human debugging can self-correct easily.
+
+## Changes
+
+### 1. Prompt hardening — `src/services/forms/shaping/bedrock-shaper.ts`
+Expand the Guidance block with:
+- An explicit multi-step id rule + a 2-line worked example.
+- Defaults awareness: `boolean` → checkbox, `choice` → radio. Skip redundant `setFieldControl`.
+- Brief reminder that ids invented for new entities should be short, stable, and reused.
+
+### 2. `addField` one-shot — `commands.ts`, `tools.ts`, `executor.ts`
+Add optional params to `addFieldSchema`:
+- `control?: 'radio' | 'select' | 'checkbox' | 'toggle'`
+- `helpText?: string`
+
+`execAddField` writes them onto the new `Requirement` when present. Tool description gains one sentence teaching the optional shortcuts. No behavior change when unused.
+
+### 3. Validation retry wrapper — new file `src/services/forms/shaping/retry.ts`
+```
+withValidationRetry(inner: FormShaper, { maxRetries?: number }): FormShaper
+```
+Wraps any `FormShaper`. On `executeBatch` failure, re-invokes the inner shaper with `previousAttempt` populated (the rejected commands + a human-readable feedback message including the failing command index, the executor error, and the list of known ids at the failure point). Default `maxRetries: 1`.
+
+Refactor: `bedrock-shaper.ts` stops throwing on validation failure — it returns `{ commands, explanation }` unconditionally. The wrapper owns validate + retry. The existing `validateCommands` helper stays exported (tests use it).
+
+Wire the wrapper around every registered shaping variant at the entrypoint where the `shapingRegistry` is built. Bedrock is the only live variant; mock/stub variants used in tests can be wrapped too since validation is deterministic.
+
+### 4. Richer executor errors — `executor.ts`
+Every "Unknown field id" / "Unknown groupId" / "Unknown pageId" / "Unknown afterPageId" etc. message appends the known ids of that type at the point of failure, e.g. `Unknown field id: X. Known field ids: [firstName, middleName, ..., certify]`. Same `ExecutorResult` shape, just a better message. Test assertions that use `toContain` on the error keep working; ones that match exactly need adjusting.
+
+### 5. Fixture intents — `src/services/evaluation/fixtures/shaping-intents.ts`
+Add three multi-step fixtures to the existing 6:
+- `add-confirmation-page` — "Add a confirmation page at the end with a checkbox" — expects `addPage(id='confirmation')` + `addGroup(id='confirmation-group', pageId='confirmation')` + `addField(id='confirmation-acknowledgment', groupId='confirmation-group', fieldType='boolean', required=true)`.
+- `add-phone-to-personal` — "Add a phone number field to personal info" — expects single `addField(groupId='personal-info', fieldType='phone')`.
+- `add-agreement-page` — "Add an agreements page with two checkboxes: terms and privacy" — `addPage` + `addGroup` + two `addField`s all wiring into the same new group id.
+
+These fixtures are used by the existing `shapingIntentFixtures` harness; they're not executed against Bedrock in `bun test` — that's the eval harness.
+
+### 6. Tests
+- `test/forms/shaping/retry.test.ts` — unit-test `withValidationRetry` with a fake inner shaper. Scenarios: success first try, success on retry, failure after max retries, feedback message contains known ids.
+- `test/forms/shaping/executor-fields.test.ts` — extend with `addField` accepting `control` and `helpText`.
+- `test/forms/shaping/executor-fields.test.ts` and siblings — confirm error messages include known-id list for at least one representative case per type.
+- `test/evaluation/shaping-commands.test.ts` — runs the expanded fixture list; existing ground-truth scoring should pass.
+
+## Out of scope
+- Running any new Bedrock eval in CI — that's scope C.
+- UI changes. Error banners already surface validation errors; they get better messages for free.
+- `addPage` / `addGroup` shape changes — only `addField` gains optional params.
+- Prompt work beyond the Guidance block (no few-shot, no RAG, no variant-specific prompts).
+
+## Success criteria
+- `bun run check` passes (lint + types + tests).
+- The original intent `'add a new "confirmation" page at the end with a checkbox'` emits a legal command sequence end-to-end against the fixture project state with the stubbed shaper that generates the expected `addPage + addGroup + addField` sequence.
+- The retry wrapper turns a transient invalid-id sequence into a successful one without user intervention.
+- No existing test regresses.

--- a/src/services/evaluation/fixtures/shaping-intents.ts
+++ b/src/services/evaluation/fixtures/shaping-intents.ts
@@ -266,6 +266,70 @@ const intents: Array<Omit<ShapingIntentFixture, 'groundTruth'>> = [
       { kind: 'setDeliveryMode', pageId: 'page-5', mode: 'static' },
     ],
   },
+  {
+    id: 'add-phone-to-personal',
+    intent: 'Add a phone number field to personal info',
+    expectedCommands: [
+      {
+        kind: 'addField',
+        groupId: 'personal-info',
+        label: 'Phone number',
+        fieldType: 'phone',
+        required: false,
+      },
+    ],
+  },
+  {
+    id: 'add-confirmation-page',
+    intent: 'Add a confirmation page at the end with a checkbox',
+    expectedCommands: [
+      { kind: 'addPage', id: 'confirmation', title: 'Confirmation' },
+      {
+        kind: 'addGroup',
+        id: 'confirmation-group',
+        pageId: 'confirmation',
+        title: 'Confirmation',
+      },
+      {
+        kind: 'addField',
+        id: 'confirm-accurate',
+        groupId: 'confirmation-group',
+        label: 'I confirm the information above is accurate',
+        fieldType: 'boolean',
+        required: true,
+      },
+    ],
+  },
+  {
+    id: 'add-agreement-page',
+    intent:
+      'Add an agreements page with two checkboxes: accept terms, accept privacy policy',
+    expectedCommands: [
+      { kind: 'addPage', id: 'agreements', title: 'Agreements' },
+      {
+        kind: 'addGroup',
+        id: 'agreements-group',
+        pageId: 'agreements',
+        title: 'Agreements',
+      },
+      {
+        kind: 'addField',
+        id: 'accept-terms',
+        groupId: 'agreements-group',
+        label: 'I accept the terms of service',
+        fieldType: 'boolean',
+        required: true,
+      },
+      {
+        kind: 'addField',
+        id: 'accept-privacy',
+        groupId: 'agreements-group',
+        label: 'I accept the privacy policy',
+        fieldType: 'boolean',
+        required: true,
+      },
+    ],
+  },
 ]
 
 export const shapingIntentFixtures: ShapingIntentFixture[] = intents.map(

--- a/src/services/forms/index.ts
+++ b/src/services/forms/index.ts
@@ -36,6 +36,7 @@ export { commandSchema } from './shaping/commands'
 export { executeBatch } from './shaping/executor'
 export { composeExplanation, humanize } from './shaping/humanize'
 export { createShapingRegistry } from './shaping/registry'
+export { validateCommands, withValidationRetry } from './shaping/retry'
 export { commandTools } from './shaping/tools'
 export type { FormShaper } from './shaping/types'
 // Storage & Sessions

--- a/src/services/forms/shaping/bedrock-shaper.ts
+++ b/src/services/forms/shaping/bedrock-shaper.ts
@@ -7,10 +7,10 @@ import type { FormShaper, ShapingRequest, ShapingResult } from './types'
 
 const DEFAULT_MODEL = 'us.anthropic.claude-sonnet-4-20250514-v1:0'
 
+export type { ValidateResult } from './retry'
 // Validation + retry moved to retry.ts so each shaper stays a pure
 // LLM → Commands mapping. Re-exported for back-compat with existing imports.
 export { validateCommands } from './retry'
-export type { ValidateResult } from './retry'
 
 function buildPrompt(request: ShapingRequest): string {
   const previous = request.previousAttempt

--- a/src/services/forms/shaping/bedrock-shaper.ts
+++ b/src/services/forms/shaping/bedrock-shaper.ts
@@ -1,34 +1,20 @@
 import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock'
 import { fromIni, fromNodeProviderChain } from '@aws-sdk/credential-providers'
 import { generateText } from 'ai'
-import type { Command, ProjectState } from './commands'
-import { executeBatch } from './executor'
+import type { Command } from './commands'
 import { commandTools } from './tools'
 import type { FormShaper, ShapingRequest, ShapingResult } from './types'
 
 const DEFAULT_MODEL = 'us.anthropic.claude-sonnet-4-20250514-v1:0'
 
-export type ValidateResult =
-  | { ok: true }
-  | { ok: false; error: string; failedAt: number; command: Command }
-
-export function validateCommands(
-  commands: Command[],
-  state: ProjectState,
-): ValidateResult {
-  const result = executeBatch(state, commands)
-  if (result.ok) return { ok: true }
-  return {
-    ok: false,
-    error: result.error,
-    failedAt: result.failedAt,
-    command: result.command,
-  }
-}
+// Validation + retry moved to retry.ts so each shaper stays a pure
+// LLM → Commands mapping. Re-exported for back-compat with existing imports.
+export { validateCommands } from './retry'
+export type { ValidateResult } from './retry'
 
 function buildPrompt(request: ShapingRequest): string {
   const previous = request.previousAttempt
-    ? `\n\n## Previous attempt\nYou previously produced these commands:\n${JSON.stringify(request.previousAttempt.commands, null, 2)}\n\nThe user said: "${request.previousAttempt.feedback}"\n`
+    ? `\n\n## Previous attempt\nYou previously produced these commands:\n${JSON.stringify(request.previousAttempt.commands, null, 2)}\n\nValidation feedback: "${request.previousAttempt.feedback}"\n`
     : ''
 
   return `You are a form design assistant. A form creator wants to modify the structure of their form. Call the appropriate tools to express the edits as a sequence of commands.
@@ -56,8 +42,15 @@ ${JSON.stringify(
 ${previous}
 
 ## Guidance
-- Call tools that match the creator's intent. The tools correspond to domain operations like swapPages, moveGroup, addField, etc.
-- Preserve page/group/field identity: use real ids from the specs above. Invent new ids only for commands that create new entities.
+- Call tools that match the creator's intent (swapPages, moveGroup, addField, etc.). Prefer the smallest set of commands that achieves the request.
+- Use existing ids from the specs above. Do NOT invent ids that reference entities that don't exist yet.
+- When creating a new page, group, or field that you need to reference in a later command (e.g., adding a group to a page you just created), pass an explicit \`id\` to the creating tool and reuse that exact id in the subsequent commands. Example:
+    addPage    { id: "confirmation",       title: "Confirmation" }
+    addGroup   { id: "confirmation-group", pageId: "confirmation", title: "Confirmation" }
+    addField   { id: "confirm-accurate",   groupId: "confirmation-group", label: "I confirm the information is accurate", fieldType: "boolean", required: true }
+  Keep invented ids short, stable, and human-readable.
+- Respect control defaults — don't issue redundant commands. \`boolean\` fields already render as a checkbox; \`choice\` fields default to radio. Only call \`setFieldControl\` to override these defaults (e.g., boolean as toggle, choice as select).
+- \`addField\` accepts optional \`control\` and \`helpText\` in one shot. Use those instead of following \`addField\` with a separate \`setFieldControl\` or \`relabelField\`.
 - When reordering, only change position — don't rewrite content.
 - After calling tools, respond with a single short sentence summarizing what you did. This sentence will be shown to the user.`
 }
@@ -94,13 +87,6 @@ export function createBedrockFormShaper(
           kind: call.toolName,
           ...(call.input as object),
         } as Command)
-      }
-
-      const validation = validateCommands(commands, request.state)
-      if (!validation.ok) {
-        throw new Error(
-          `LLM produced invalid command sequence: ${validation.error} (command ${validation.failedAt})`,
-        )
       }
 
       const explanation =

--- a/src/services/forms/shaping/commands.ts
+++ b/src/services/forms/shaping/commands.ts
@@ -163,6 +163,8 @@ const addFieldSchema = z.object({
   label: z.string(),
   fieldType: fieldTypeSchema,
   required: z.boolean(),
+  control: controlSchema.optional(),
+  helpText: z.string().optional(),
 })
 const removeFieldSchema = z.object({
   kind: z.literal('removeField'),

--- a/src/services/forms/shaping/executor.ts
+++ b/src/services/forms/shaping/executor.ts
@@ -49,6 +49,56 @@ function generateFieldId(): string {
   return `field-new-${crypto.randomUUID().slice(0, 8)}`
 }
 
+function pageIds(state: ProjectState): string {
+  return state.formSpec.pages.map((p) => p.id).join(', ')
+}
+
+function groupIds(state: ProjectState): string {
+  return state.dataSpec.groups.map((g) => g.id).join(', ')
+}
+
+function fieldIds(state: ProjectState): string {
+  return state.dataSpec.groups
+    .flatMap((g) => g.requirements.map((r) => r.id))
+    .join(', ')
+}
+
+function failUnknownPage(
+  command: Command,
+  label: string,
+  id: string,
+  state: ProjectState,
+): ExecutorResult {
+  return fail(
+    command,
+    `Unknown ${label}: ${id}. Known page ids: [${pageIds(state)}]`,
+  )
+}
+
+function failUnknownGroup(
+  command: Command,
+  label: string,
+  id: string,
+  state: ProjectState,
+): ExecutorResult {
+  return fail(
+    command,
+    `Unknown ${label}: ${id}. Known group ids: [${groupIds(state)}]`,
+  )
+}
+
+function failUnknownField(
+  command: Command,
+  label: string,
+  id: string,
+  state: ProjectState,
+): ExecutorResult {
+  return fail(
+    command,
+    `Unknown ${label}: ${id}. Known field ids: [${fieldIds(state)}]`,
+  )
+}
+
 export function executeCommand(
   state: ProjectState,
   command: Command,
@@ -136,8 +186,8 @@ function execSwapPages(
   const formSpec = cloneFormSpec(state.formSpec)
   const aIdx = formSpec.pages.findIndex((p) => p.id === command.a)
   const bIdx = formSpec.pages.findIndex((p) => p.id === command.b)
-  if (aIdx < 0) return fail(command, `Unknown page id: ${command.a}`)
-  if (bIdx < 0) return fail(command, `Unknown page id: ${command.b}`)
+  if (aIdx < 0) return failUnknownPage(command, 'page id', command.a, state)
+  if (bIdx < 0) return failUnknownPage(command, 'page id', command.b, state)
   ;[formSpec.pages[aIdx], formSpec.pages[bIdx]] = [
     formSpec.pages[bIdx],
     formSpec.pages[aIdx],
@@ -151,7 +201,7 @@ function execMovePage(
 ): ExecutorResult {
   const formSpec = cloneFormSpec(state.formSpec)
   const idx = formSpec.pages.findIndex((p) => p.id === command.id)
-  if (idx < 0) return fail(command, `Unknown page id: ${command.id}`)
+  if (idx < 0) return failUnknownPage(command, 'page id', command.id, state)
   if (command.toIndex < 0 || command.toIndex >= formSpec.pages.length) {
     return fail(command, `toIndex out of range: ${command.toIndex}`)
   }
@@ -174,7 +224,7 @@ function execAddPage(
   if (command.afterPageId) {
     const idx = formSpec.pages.findIndex((p) => p.id === command.afterPageId)
     if (idx < 0) {
-      return fail(command, `Unknown afterPageId: ${command.afterPageId}`)
+      return failUnknownPage(command, 'afterPageId', command.afterPageId, state)
     }
     formSpec.pages.splice(idx + 1, 0, newPage)
   } else {
@@ -189,7 +239,7 @@ function execRemovePage(
 ): ExecutorResult {
   const formSpec = cloneFormSpec(state.formSpec)
   const idx = formSpec.pages.findIndex((p) => p.id === command.id)
-  if (idx < 0) return fail(command, `Unknown page id: ${command.id}`)
+  if (idx < 0) return failUnknownPage(command, 'page id', command.id, state)
   const page = formSpec.pages[idx]
   if (page.groups.length > 0 && !command.moveGroupsTo) {
     return fail(
@@ -202,7 +252,12 @@ function execRemovePage(
       (p) => p.id === command.moveGroupsTo,
     )
     if (destIdx < 0) {
-      return fail(command, `Unknown moveGroupsTo page: ${command.moveGroupsTo}`)
+      return failUnknownPage(
+        command,
+        'moveGroupsTo',
+        command.moveGroupsTo,
+        state,
+      )
     }
     formSpec.pages[destIdx] = {
       ...formSpec.pages[destIdx],
@@ -219,7 +274,7 @@ function execRenamePage(
 ): ExecutorResult {
   const formSpec = cloneFormSpec(state.formSpec)
   const idx = formSpec.pages.findIndex((p) => p.id === command.id)
-  if (idx < 0) return fail(command, `Unknown page id: ${command.id}`)
+  if (idx < 0) return failUnknownPage(command, 'page id', command.id, state)
   formSpec.pages[idx] = { ...formSpec.pages[idx], title: command.title }
   return ok({ ...state, formSpec })
 }
@@ -230,7 +285,7 @@ function execSplitPage(
 ): ExecutorResult {
   const formSpec = cloneFormSpec(state.formSpec)
   const idx = formSpec.pages.findIndex((p) => p.id === command.id)
-  if (idx < 0) return fail(command, `Unknown page id: ${command.id}`)
+  if (idx < 0) return failUnknownPage(command, 'page id', command.id, state)
   const source = formSpec.pages[idx]
   for (const gid of command.groupsToMove) {
     if (!source.groups.includes(gid)) {
@@ -257,8 +312,8 @@ function execMergePages(
   const formSpec = cloneFormSpec(state.formSpec)
   const intoIdx = formSpec.pages.findIndex((p) => p.id === command.intoId)
   const fromIdx = formSpec.pages.findIndex((p) => p.id === command.fromId)
-  if (intoIdx < 0) return fail(command, `Unknown intoId: ${command.intoId}`)
-  if (fromIdx < 0) return fail(command, `Unknown fromId: ${command.fromId}`)
+  if (intoIdx < 0) return failUnknownPage(command, 'intoId', command.intoId, state)
+  if (fromIdx < 0) return failUnknownPage(command, 'fromId', command.fromId, state)
   formSpec.pages[intoIdx] = {
     ...formSpec.pages[intoIdx],
     groups: [
@@ -276,7 +331,7 @@ function execSetDeliveryMode(
 ): ExecutorResult {
   const formSpec = cloneFormSpec(state.formSpec)
   const idx = formSpec.pages.findIndex((p) => p.id === command.pageId)
-  if (idx < 0) return fail(command, `Unknown pageId: ${command.pageId}`)
+  if (idx < 0) return failUnknownPage(command, 'pageId', command.pageId, state)
   formSpec.pages[idx] = { ...formSpec.pages[idx], deliveryMode: command.mode }
   return ok({ ...state, formSpec })
 }
@@ -289,9 +344,9 @@ function execMoveGroup(
   const fromPage = formSpec.pages.find((p) =>
     p.groups.includes(command.groupId),
   )
-  if (!fromPage) return fail(command, `Unknown groupId: ${command.groupId}`)
+  if (!fromPage) return failUnknownGroup(command, 'groupId', command.groupId, state)
   const toPage = formSpec.pages.find((p) => p.id === command.toPageId)
-  if (!toPage) return fail(command, `Unknown toPageId: ${command.toPageId}`)
+  if (!toPage) return failUnknownPage(command, 'toPageId', command.toPageId, state)
   fromPage.groups = fromPage.groups.filter((g) => g !== command.groupId)
   const atIndex = command.atIndex ?? toPage.groups.length
   toPage.groups.splice(atIndex, 0, command.groupId)
@@ -304,7 +359,7 @@ function execRenameGroup(
 ): ExecutorResult {
   const dataSpec = cloneDataSpec(state.dataSpec)
   const idx = dataSpec.groups.findIndex((g) => g.id === command.id)
-  if (idx < 0) return fail(command, `Unknown group id: ${command.id}`)
+  if (idx < 0) return failUnknownGroup(command, 'group id', command.id, state)
   dataSpec.groups[idx] = { ...dataSpec.groups[idx], title: command.title }
   return ok({ ...state, dataSpec })
 }
@@ -315,7 +370,7 @@ function execAddGroup(
 ): ExecutorResult {
   const formSpec = cloneFormSpec(state.formSpec)
   const pageIdx = formSpec.pages.findIndex((p) => p.id === command.pageId)
-  if (pageIdx < 0) return fail(command, `Unknown pageId: ${command.pageId}`)
+  if (pageIdx < 0) return failUnknownPage(command, 'pageId', command.pageId, state)
   const dataSpec = cloneDataSpec(state.dataSpec)
   const newGroup: RequirementGroup = {
     id: command.id ?? generateGroupId(),
@@ -335,7 +390,7 @@ function execRemoveGroup(
   command: Extract<Command, { kind: 'removeGroup' }>,
 ): ExecutorResult {
   const group = state.dataSpec.groups.find((g) => g.id === command.id)
-  if (!group) return fail(command, `Unknown group id: ${command.id}`)
+  if (!group) return failUnknownGroup(command, 'group id', command.id, state)
 
   if (group.requirements.length > 0 && !command.moveFieldsTo) {
     return fail(
@@ -350,9 +405,11 @@ function execRemoveGroup(
       (g) => g.id === command.moveFieldsTo,
     )
     if (destIdx < 0) {
-      return fail(
+      return failUnknownGroup(
         command,
-        `Unknown moveFieldsTo group: ${command.moveFieldsTo}`,
+        'moveFieldsTo',
+        command.moveFieldsTo,
+        state,
       )
     }
     dataSpec.groups[destIdx] = {
@@ -377,7 +434,7 @@ function execSplitGroup(
   command: Extract<Command, { kind: 'splitGroup' }>,
 ): ExecutorResult {
   const sourceIdx = state.dataSpec.groups.findIndex((g) => g.id === command.id)
-  if (sourceIdx < 0) return fail(command, `Unknown group id: ${command.id}`)
+  if (sourceIdx < 0) return failUnknownGroup(command, 'group id', command.id, state)
   const source = state.dataSpec.groups[sourceIdx]
   for (const fid of command.fieldsToMove) {
     if (!source.requirements.find((r) => r.id === fid)) {
@@ -417,8 +474,8 @@ function execMergeGroups(
   const dataSpec = cloneDataSpec(state.dataSpec)
   const intoIdx = dataSpec.groups.findIndex((g) => g.id === command.intoId)
   const fromIdx = dataSpec.groups.findIndex((g) => g.id === command.fromId)
-  if (intoIdx < 0) return fail(command, `Unknown intoId: ${command.intoId}`)
-  if (fromIdx < 0) return fail(command, `Unknown fromId: ${command.fromId}`)
+  if (intoIdx < 0) return failUnknownGroup(command, 'intoId', command.intoId, state)
+  if (fromIdx < 0) return failUnknownGroup(command, 'fromId', command.fromId, state)
 
   dataSpec.groups[intoIdx] = {
     ...dataSpec.groups[intoIdx],
@@ -441,11 +498,11 @@ function execMoveField(
   command: Extract<Command, { kind: 'moveField' }>,
 ): ExecutorResult {
   const fromIdx = findFieldGroupIdx(state, command.fieldId)
-  if (fromIdx < 0) return fail(command, `Unknown fieldId: ${command.fieldId}`)
+  if (fromIdx < 0) return failUnknownField(command, 'fieldId', command.fieldId, state)
   const toIdx = state.dataSpec.groups.findIndex(
     (g) => g.id === command.toGroupId,
   )
-  if (toIdx < 0) return fail(command, `Unknown toGroupId: ${command.toGroupId}`)
+  if (toIdx < 0) return failUnknownGroup(command, 'toGroupId', command.toGroupId, state)
   const dataSpec = cloneDataSpec(state.dataSpec)
   const field = dataSpec.groups[fromIdx].requirements.find(
     (r) => r.id === command.fieldId,
@@ -471,7 +528,7 @@ function execReorderFields(
   const groupIdx = state.dataSpec.groups.findIndex(
     (g) => g.id === command.groupId,
   )
-  if (groupIdx < 0) return fail(command, `Unknown groupId: ${command.groupId}`)
+  if (groupIdx < 0) return failUnknownGroup(command, 'groupId', command.groupId, state)
   const group = state.dataSpec.groups[groupIdx]
   const currentIds = group.requirements.map((r) => r.id)
   if (
@@ -501,7 +558,7 @@ function execRelabelField(
   command: Extract<Command, { kind: 'relabelField' }>,
 ): ExecutorResult {
   const groupIdx = findFieldGroupIdx(state, command.id)
-  if (groupIdx < 0) return fail(command, `Unknown field id: ${command.id}`)
+  if (groupIdx < 0) return failUnknownField(command, 'field id', command.id, state)
   const dataSpec = cloneDataSpec(state.dataSpec)
   dataSpec.groups[groupIdx].requirements = dataSpec.groups[
     groupIdx
@@ -522,7 +579,7 @@ function execSetRequired(
   command: Extract<Command, { kind: 'setRequired' }>,
 ): ExecutorResult {
   const groupIdx = findFieldGroupIdx(state, command.id)
-  if (groupIdx < 0) return fail(command, `Unknown field id: ${command.id}`)
+  if (groupIdx < 0) return failUnknownField(command, 'field id', command.id, state)
   const dataSpec = cloneDataSpec(state.dataSpec)
   dataSpec.groups[groupIdx].requirements = dataSpec.groups[
     groupIdx
@@ -537,7 +594,7 @@ function execSetFieldCondition(
   command: Extract<Command, { kind: 'setFieldCondition' }>,
 ): ExecutorResult {
   const groupIdx = findFieldGroupIdx(state, command.id)
-  if (groupIdx < 0) return fail(command, `Unknown field id: ${command.id}`)
+  if (groupIdx < 0) return failUnknownField(command, 'field id', command.id, state)
   const dataSpec = cloneDataSpec(state.dataSpec)
   dataSpec.groups[groupIdx].requirements = dataSpec.groups[
     groupIdx
@@ -554,7 +611,7 @@ function execSetFieldSensitivity(
   command: Extract<Command, { kind: 'setFieldSensitivity' }>,
 ): ExecutorResult {
   const groupIdx = findFieldGroupIdx(state, command.id)
-  if (groupIdx < 0) return fail(command, `Unknown field id: ${command.id}`)
+  if (groupIdx < 0) return failUnknownField(command, 'field id', command.id, state)
   const dataSpec = cloneDataSpec(state.dataSpec)
   dataSpec.groups[groupIdx].requirements = dataSpec.groups[
     groupIdx
@@ -569,7 +626,7 @@ function execChangeFieldType(
   command: Extract<Command, { kind: 'changeFieldType' }>,
 ): ExecutorResult {
   const groupIdx = findFieldGroupIdx(state, command.id)
-  if (groupIdx < 0) return fail(command, `Unknown field id: ${command.id}`)
+  if (groupIdx < 0) return failUnknownField(command, 'field id', command.id, state)
   const dataSpec = cloneDataSpec(state.dataSpec)
   dataSpec.groups[groupIdx].requirements = dataSpec.groups[
     groupIdx
@@ -590,7 +647,7 @@ function execSetFieldControl(
   command: Extract<Command, { kind: 'setFieldControl' }>,
 ): ExecutorResult {
   const groupIdx = findFieldGroupIdx(state, command.id)
-  if (groupIdx < 0) return fail(command, `Unknown field id: ${command.id}`)
+  if (groupIdx < 0) return failUnknownField(command, 'field id', command.id, state)
   const dataSpec = cloneDataSpec(state.dataSpec)
   dataSpec.groups[groupIdx].requirements = dataSpec.groups[
     groupIdx
@@ -607,7 +664,7 @@ function execAddField(
   const groupIdx = state.dataSpec.groups.findIndex(
     (g) => g.id === command.groupId,
   )
-  if (groupIdx < 0) return fail(command, `Unknown groupId: ${command.groupId}`)
+  if (groupIdx < 0) return failUnknownGroup(command, 'groupId', command.groupId, state)
   const dataSpec = cloneDataSpec(state.dataSpec)
   const newField: DataRequirement = {
     id: command.id ?? generateFieldId(),
@@ -630,7 +687,7 @@ function execRemoveField(
   command: Extract<Command, { kind: 'removeField' }>,
 ): ExecutorResult {
   const groupIdx = findFieldGroupIdx(state, command.id)
-  if (groupIdx < 0) return fail(command, `Unknown field id: ${command.id}`)
+  if (groupIdx < 0) return failUnknownField(command, 'field id', command.id, state)
   const dataSpec = cloneDataSpec(state.dataSpec)
   dataSpec.groups[groupIdx] = {
     ...dataSpec.groups[groupIdx],

--- a/src/services/forms/shaping/executor.ts
+++ b/src/services/forms/shaping/executor.ts
@@ -312,8 +312,10 @@ function execMergePages(
   const formSpec = cloneFormSpec(state.formSpec)
   const intoIdx = formSpec.pages.findIndex((p) => p.id === command.intoId)
   const fromIdx = formSpec.pages.findIndex((p) => p.id === command.fromId)
-  if (intoIdx < 0) return failUnknownPage(command, 'intoId', command.intoId, state)
-  if (fromIdx < 0) return failUnknownPage(command, 'fromId', command.fromId, state)
+  if (intoIdx < 0)
+    return failUnknownPage(command, 'intoId', command.intoId, state)
+  if (fromIdx < 0)
+    return failUnknownPage(command, 'fromId', command.fromId, state)
   formSpec.pages[intoIdx] = {
     ...formSpec.pages[intoIdx],
     groups: [
@@ -344,9 +346,11 @@ function execMoveGroup(
   const fromPage = formSpec.pages.find((p) =>
     p.groups.includes(command.groupId),
   )
-  if (!fromPage) return failUnknownGroup(command, 'groupId', command.groupId, state)
+  if (!fromPage)
+    return failUnknownGroup(command, 'groupId', command.groupId, state)
   const toPage = formSpec.pages.find((p) => p.id === command.toPageId)
-  if (!toPage) return failUnknownPage(command, 'toPageId', command.toPageId, state)
+  if (!toPage)
+    return failUnknownPage(command, 'toPageId', command.toPageId, state)
   fromPage.groups = fromPage.groups.filter((g) => g !== command.groupId)
   const atIndex = command.atIndex ?? toPage.groups.length
   toPage.groups.splice(atIndex, 0, command.groupId)
@@ -370,7 +374,8 @@ function execAddGroup(
 ): ExecutorResult {
   const formSpec = cloneFormSpec(state.formSpec)
   const pageIdx = formSpec.pages.findIndex((p) => p.id === command.pageId)
-  if (pageIdx < 0) return failUnknownPage(command, 'pageId', command.pageId, state)
+  if (pageIdx < 0)
+    return failUnknownPage(command, 'pageId', command.pageId, state)
   const dataSpec = cloneDataSpec(state.dataSpec)
   const newGroup: RequirementGroup = {
     id: command.id ?? generateGroupId(),
@@ -434,7 +439,8 @@ function execSplitGroup(
   command: Extract<Command, { kind: 'splitGroup' }>,
 ): ExecutorResult {
   const sourceIdx = state.dataSpec.groups.findIndex((g) => g.id === command.id)
-  if (sourceIdx < 0) return failUnknownGroup(command, 'group id', command.id, state)
+  if (sourceIdx < 0)
+    return failUnknownGroup(command, 'group id', command.id, state)
   const source = state.dataSpec.groups[sourceIdx]
   for (const fid of command.fieldsToMove) {
     if (!source.requirements.find((r) => r.id === fid)) {
@@ -474,8 +480,10 @@ function execMergeGroups(
   const dataSpec = cloneDataSpec(state.dataSpec)
   const intoIdx = dataSpec.groups.findIndex((g) => g.id === command.intoId)
   const fromIdx = dataSpec.groups.findIndex((g) => g.id === command.fromId)
-  if (intoIdx < 0) return failUnknownGroup(command, 'intoId', command.intoId, state)
-  if (fromIdx < 0) return failUnknownGroup(command, 'fromId', command.fromId, state)
+  if (intoIdx < 0)
+    return failUnknownGroup(command, 'intoId', command.intoId, state)
+  if (fromIdx < 0)
+    return failUnknownGroup(command, 'fromId', command.fromId, state)
 
   dataSpec.groups[intoIdx] = {
     ...dataSpec.groups[intoIdx],
@@ -498,11 +506,13 @@ function execMoveField(
   command: Extract<Command, { kind: 'moveField' }>,
 ): ExecutorResult {
   const fromIdx = findFieldGroupIdx(state, command.fieldId)
-  if (fromIdx < 0) return failUnknownField(command, 'fieldId', command.fieldId, state)
+  if (fromIdx < 0)
+    return failUnknownField(command, 'fieldId', command.fieldId, state)
   const toIdx = state.dataSpec.groups.findIndex(
     (g) => g.id === command.toGroupId,
   )
-  if (toIdx < 0) return failUnknownGroup(command, 'toGroupId', command.toGroupId, state)
+  if (toIdx < 0)
+    return failUnknownGroup(command, 'toGroupId', command.toGroupId, state)
   const dataSpec = cloneDataSpec(state.dataSpec)
   const field = dataSpec.groups[fromIdx].requirements.find(
     (r) => r.id === command.fieldId,
@@ -528,7 +538,8 @@ function execReorderFields(
   const groupIdx = state.dataSpec.groups.findIndex(
     (g) => g.id === command.groupId,
   )
-  if (groupIdx < 0) return failUnknownGroup(command, 'groupId', command.groupId, state)
+  if (groupIdx < 0)
+    return failUnknownGroup(command, 'groupId', command.groupId, state)
   const group = state.dataSpec.groups[groupIdx]
   const currentIds = group.requirements.map((r) => r.id)
   if (
@@ -558,7 +569,8 @@ function execRelabelField(
   command: Extract<Command, { kind: 'relabelField' }>,
 ): ExecutorResult {
   const groupIdx = findFieldGroupIdx(state, command.id)
-  if (groupIdx < 0) return failUnknownField(command, 'field id', command.id, state)
+  if (groupIdx < 0)
+    return failUnknownField(command, 'field id', command.id, state)
   const dataSpec = cloneDataSpec(state.dataSpec)
   dataSpec.groups[groupIdx].requirements = dataSpec.groups[
     groupIdx
@@ -579,7 +591,8 @@ function execSetRequired(
   command: Extract<Command, { kind: 'setRequired' }>,
 ): ExecutorResult {
   const groupIdx = findFieldGroupIdx(state, command.id)
-  if (groupIdx < 0) return failUnknownField(command, 'field id', command.id, state)
+  if (groupIdx < 0)
+    return failUnknownField(command, 'field id', command.id, state)
   const dataSpec = cloneDataSpec(state.dataSpec)
   dataSpec.groups[groupIdx].requirements = dataSpec.groups[
     groupIdx
@@ -594,7 +607,8 @@ function execSetFieldCondition(
   command: Extract<Command, { kind: 'setFieldCondition' }>,
 ): ExecutorResult {
   const groupIdx = findFieldGroupIdx(state, command.id)
-  if (groupIdx < 0) return failUnknownField(command, 'field id', command.id, state)
+  if (groupIdx < 0)
+    return failUnknownField(command, 'field id', command.id, state)
   const dataSpec = cloneDataSpec(state.dataSpec)
   dataSpec.groups[groupIdx].requirements = dataSpec.groups[
     groupIdx
@@ -611,7 +625,8 @@ function execSetFieldSensitivity(
   command: Extract<Command, { kind: 'setFieldSensitivity' }>,
 ): ExecutorResult {
   const groupIdx = findFieldGroupIdx(state, command.id)
-  if (groupIdx < 0) return failUnknownField(command, 'field id', command.id, state)
+  if (groupIdx < 0)
+    return failUnknownField(command, 'field id', command.id, state)
   const dataSpec = cloneDataSpec(state.dataSpec)
   dataSpec.groups[groupIdx].requirements = dataSpec.groups[
     groupIdx
@@ -626,7 +641,8 @@ function execChangeFieldType(
   command: Extract<Command, { kind: 'changeFieldType' }>,
 ): ExecutorResult {
   const groupIdx = findFieldGroupIdx(state, command.id)
-  if (groupIdx < 0) return failUnknownField(command, 'field id', command.id, state)
+  if (groupIdx < 0)
+    return failUnknownField(command, 'field id', command.id, state)
   const dataSpec = cloneDataSpec(state.dataSpec)
   dataSpec.groups[groupIdx].requirements = dataSpec.groups[
     groupIdx
@@ -647,7 +663,8 @@ function execSetFieldControl(
   command: Extract<Command, { kind: 'setFieldControl' }>,
 ): ExecutorResult {
   const groupIdx = findFieldGroupIdx(state, command.id)
-  if (groupIdx < 0) return failUnknownField(command, 'field id', command.id, state)
+  if (groupIdx < 0)
+    return failUnknownField(command, 'field id', command.id, state)
   const dataSpec = cloneDataSpec(state.dataSpec)
   dataSpec.groups[groupIdx].requirements = dataSpec.groups[
     groupIdx
@@ -664,7 +681,8 @@ function execAddField(
   const groupIdx = state.dataSpec.groups.findIndex(
     (g) => g.id === command.groupId,
   )
-  if (groupIdx < 0) return failUnknownGroup(command, 'groupId', command.groupId, state)
+  if (groupIdx < 0)
+    return failUnknownGroup(command, 'groupId', command.groupId, state)
   const dataSpec = cloneDataSpec(state.dataSpec)
   const newField: DataRequirement = {
     id: command.id ?? generateFieldId(),
@@ -687,7 +705,8 @@ function execRemoveField(
   command: Extract<Command, { kind: 'removeField' }>,
 ): ExecutorResult {
   const groupIdx = findFieldGroupIdx(state, command.id)
-  if (groupIdx < 0) return failUnknownField(command, 'field id', command.id, state)
+  if (groupIdx < 0)
+    return failUnknownField(command, 'field id', command.id, state)
   const dataSpec = cloneDataSpec(state.dataSpec)
   dataSpec.groups[groupIdx] = {
     ...dataSpec.groups[groupIdx],

--- a/src/services/forms/shaping/executor.ts
+++ b/src/services/forms/shaping/executor.ts
@@ -1,5 +1,6 @@
 import type {
   DataCollectionSpec,
+  DataRequirement,
   RequirementGroup,
 } from '../../data-collection'
 import type { FormPage, FormSpec } from '../types'
@@ -608,12 +609,14 @@ function execAddField(
   )
   if (groupIdx < 0) return fail(command, `Unknown groupId: ${command.groupId}`)
   const dataSpec = cloneDataSpec(state.dataSpec)
-  const newField = {
+  const newField: DataRequirement = {
     id: command.id ?? generateFieldId(),
     fieldName: command.label.toLowerCase().replace(/\s+/g, '_').slice(0, 40),
     label: command.label,
     fieldType: command.fieldType,
     required: command.required,
+    ...(command.control ? { control: command.control } : {}),
+    ...(command.helpText ? { helpText: command.helpText } : {}),
   }
   dataSpec.groups[groupIdx] = {
     ...dataSpec.groups[groupIdx],

--- a/src/services/forms/shaping/registry.ts
+++ b/src/services/forms/shaping/registry.ts
@@ -5,7 +5,12 @@ import {
   SONNET_MODEL_ID,
 } from '../../extraction'
 import { createBedrockFormShaper } from './bedrock-shaper'
+import { withValidationRetry } from './retry'
 import type { FormShaper } from './types'
+
+function registeredShaper(model: string): FormShaper {
+  return withValidationRetry(createBedrockFormShaper({ model }))
+}
 
 export function createShapingRegistry(): StrategyRegistry<FormShaper> {
   const registry = new StrategyRegistry<FormShaper>()
@@ -21,7 +26,7 @@ export function createShapingRegistry(): StrategyRegistry<FormShaper> {
       catalogPath: '/catalog/experiments/shaping-model-comparison/sonnet',
       modelId: SONNET_MODEL_ID,
     },
-    create: () => createBedrockFormShaper({ model: SONNET_MODEL_ID }),
+    create: () => registeredShaper(SONNET_MODEL_ID),
   })
 
   registry.register({
@@ -35,7 +40,7 @@ export function createShapingRegistry(): StrategyRegistry<FormShaper> {
       catalogPath: '/catalog/experiments/shaping-model-comparison/haiku',
       modelId: HAIKU_MODEL_ID,
     },
-    create: () => createBedrockFormShaper({ model: HAIKU_MODEL_ID }),
+    create: () => registeredShaper(HAIKU_MODEL_ID),
   })
 
   registry.register({
@@ -49,7 +54,7 @@ export function createShapingRegistry(): StrategyRegistry<FormShaper> {
       catalogPath: '/catalog/experiments/shaping-model-comparison/opus',
       modelId: OPUS_MODEL_ID,
     },
-    create: () => createBedrockFormShaper({ model: OPUS_MODEL_ID }),
+    create: () => registeredShaper(OPUS_MODEL_ID),
   })
 
   registry.setDefault('bedrock-sonnet')

--- a/src/services/forms/shaping/retry.ts
+++ b/src/services/forms/shaping/retry.ts
@@ -1,0 +1,73 @@
+import type { Command, ProjectState } from './commands'
+import { executeBatch } from './executor'
+import type { FormShaper, ShapingRequest, ShapingResult } from './types'
+
+export interface RetryOptions {
+  maxRetries?: number
+}
+
+export type ValidateResult =
+  | { ok: true }
+  | { ok: false; error: string; failedAt: number; command: Command }
+
+export function withValidationRetry(
+  inner: FormShaper,
+  options: RetryOptions = {},
+): FormShaper {
+  const maxRetries = options.maxRetries ?? 1
+
+  return {
+    async shape(request: ShapingRequest): Promise<ShapingResult> {
+      let attempt = await inner.shape(request)
+      let validation = executeBatch(request.state, attempt.commands)
+      if (validation.ok) return attempt
+
+      for (let retry = 0; retry < maxRetries; retry++) {
+        const feedback = buildFeedback(
+          attempt.commands,
+          validation.failedAt,
+          validation.error,
+        )
+        attempt = await inner.shape({
+          intent: request.intent,
+          state: request.state,
+          previousAttempt: { commands: attempt.commands, feedback },
+        })
+        validation = executeBatch(request.state, attempt.commands)
+        if (validation.ok) return attempt
+      }
+
+      throw new Error(
+        `LLM produced invalid command sequence: ${validation.error} (command ${validation.failedAt})`,
+      )
+    },
+  }
+}
+
+function buildFeedback(
+  commands: Command[],
+  failedAt: number,
+  error: string,
+): string {
+  return [
+    `Your previous batch failed validation at command ${failedAt}: ${error}`,
+    'When you need to reference a new page/group/field in a later command, pass an explicit `id` to the creating tool and reuse that exact id in all subsequent commands.',
+    'Emit a corrected command sequence.',
+  ].join(' ')
+}
+
+// Re-export a thin validation helper so callers that only want to validate
+// (no retry) keep a stable import surface.
+export function validateCommands(
+  commands: Command[],
+  state: ProjectState,
+): ValidateResult {
+  const result = executeBatch(state, commands)
+  if (result.ok) return { ok: true }
+  return {
+    ok: false,
+    error: result.error,
+    failedAt: result.failedAt,
+    command: result.command,
+  }
+}

--- a/src/services/forms/shaping/tools.ts
+++ b/src/services/forms/shaping/tools.ts
@@ -184,13 +184,15 @@ export const commandTools = {
   }),
   addField: tool({
     description:
-      'Add a new field to a group. Optionally specify an id to reference this field in subsequent commands.',
+      'Add a new field to a group. Optionally specify id (to reference in later commands), control (only needed to override the default for the field type), and helpText. Use these shortcuts to avoid separate setFieldControl / relabelField commands.',
     inputSchema: z.object({
       id: z.string().optional(),
       groupId: z.string(),
       label: z.string(),
       fieldType,
       required: z.boolean(),
+      control: control.optional(),
+      helpText: z.string().optional(),
     }),
   }),
   removeField: tool({

--- a/test/evaluate-shaping-cli.test.ts
+++ b/test/evaluate-shaping-cli.test.ts
@@ -65,37 +65,12 @@ describe('evaluate shaping CLI subcommand', () => {
     expect(exitCode).toBe(1)
   })
 
-  it('writes JSON and markdown with six cases when all intents succeed', async () => {
-    const expectedCommandByIntentId: Record<string, Command[]> = {
-      'swap-pages': [{ kind: 'swapPages', a: 'page-2', b: 'page-3' }],
-      'merge-employment': [
-        { kind: 'mergePages', intoId: 'page-2', fromId: 'page-3' },
-      ],
-      'optional-middle-name': [
-        { kind: 'setRequired', id: 'middleName', required: false },
-      ],
-      'move-military': [
-        {
-          kind: 'moveGroup',
-          groupId: 'military-service',
-          toPageId: 'page-4',
-        },
-      ],
-      'rename-personal-info': [
-        { kind: 'renamePage', id: 'page-1', title: 'Applicant Information' },
-      ],
-      'suggest-delivery-modes': [
-        { kind: 'setDeliveryMode', pageId: 'page-1', mode: 'static' },
-        { kind: 'setDeliveryMode', pageId: 'page-2', mode: 'static' },
-        { kind: 'setDeliveryMode', pageId: 'page-3', mode: 'static' },
-        {
-          kind: 'setDeliveryMode',
-          pageId: 'page-4',
-          mode: 'conversational',
-        },
-        { kind: 'setDeliveryMode', pageId: 'page-5', mode: 'static' },
-      ],
-    }
+  it('writes JSON and markdown with all cases when all intents succeed', async () => {
+    const { shapingIntentFixtures: _probe } = await import(
+      '../src/services/evaluation/fixtures/shaping-intents'
+    )
+    const expectedCommandByIntentId: Record<string, Command[]> =
+      Object.fromEntries(_probe.map((f) => [f.id, f.expectedCommands]))
 
     const { shapingIntentFixtures } = await import(
       '../src/services/evaluation/fixtures/shaping-intents'
@@ -128,7 +103,7 @@ describe('evaluate shaping CLI subcommand', () => {
 
     expect(raw.kind).toBe('shaping-commands')
     expect(raw.implementation).toBe('bedrock-mock')
-    expect(raw.cases).toHaveLength(6)
+    expect(raw.cases).toHaveLength(_probe.length)
     expect(raw.summary.kindRecall).toBe(1)
     expect(raw.summary.kindPrecision).toBe(1)
     expect(raw.summary.argumentAccuracy).toBe(1)
@@ -174,7 +149,7 @@ describe('evaluate shaping CLI subcommand', () => {
     const raw = JSON.parse(
       readFileSync(join(tempDir, 'bedrock-mock.json'), 'utf-8'),
     )
-    expect(raw.cases).toHaveLength(6)
+    expect(raw.cases).toHaveLength(shapingIntentFixtures.length)
     const failedCase = raw.cases.find(
       (c: { fixture: string }) => c.fixture === 'swap-pages',
     )

--- a/test/evaluation/shaping-intents.test.ts
+++ b/test/evaluation/shaping-intents.test.ts
@@ -10,12 +10,9 @@ describe('shaping intent fixtures', () => {
     expect(shapingIntentFixtures.length).toBe(9)
   })
 
-  it('every fixture\'s expectedCommands execute cleanly against the project state', () => {
+  it("every fixture's expectedCommands execute cleanly against the project state", () => {
     for (const fixture of shapingIntentFixtures) {
-      const result = executeBatch(
-        fixtureProjectState,
-        fixture.expectedCommands,
-      )
+      const result = executeBatch(fixtureProjectState, fixture.expectedCommands)
       if (!result.ok) {
         throw new Error(
           `fixture "${fixture.id}" failed at command ${result.failedAt}: ${result.error}`,

--- a/test/evaluation/shaping-intents.test.ts
+++ b/test/evaluation/shaping-intents.test.ts
@@ -3,10 +3,26 @@ import {
   fixtureProjectState,
   shapingIntentFixtures,
 } from '../../src/services/evaluation/fixtures/shaping-intents'
+import { executeBatch } from '../../src/services/forms'
 
 describe('shaping intent fixtures', () => {
-  it('provides 6 scripted intents', () => {
-    expect(shapingIntentFixtures.length).toBe(6)
+  it('provides 9 scripted intents', () => {
+    expect(shapingIntentFixtures.length).toBe(9)
+  })
+
+  it('every fixture\'s expectedCommands execute cleanly against the project state', () => {
+    for (const fixture of shapingIntentFixtures) {
+      const result = executeBatch(
+        fixtureProjectState,
+        fixture.expectedCommands,
+      )
+      if (!result.ok) {
+        throw new Error(
+          `fixture "${fixture.id}" failed at command ${result.failedAt}: ${result.error}`,
+        )
+      }
+      expect(result.ok).toBe(true)
+    }
   })
 
   it('each fixture has a unique id', () => {

--- a/test/forms/shaping/executor-fields.test.ts
+++ b/test/forms/shaping/executor-fields.test.ts
@@ -213,6 +213,44 @@ describe('executor — field commands', () => {
     }
   })
 
+  it('addField accepts optional control and helpText', () => {
+    const result = executeCommand(fixture(), {
+      kind: 'addField',
+      groupId: 'g2',
+      label: 'Agree to terms',
+      fieldType: 'boolean',
+      required: true,
+      control: 'checkbox',
+      helpText: 'Please read the terms first.',
+    })
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      const added = result.state.dataSpec.groups
+        .find((g) => g.id === 'g2')!
+        .requirements.find((r) => r.label === 'Agree to terms')
+      expect(added?.control).toBe('checkbox')
+      expect(added?.helpText).toBe('Please read the terms first.')
+    }
+  })
+
+  it('addField omits optional fields when not provided', () => {
+    const result = executeCommand(fixture(), {
+      kind: 'addField',
+      groupId: 'g2',
+      label: 'Plain field',
+      fieldType: 'text',
+      required: false,
+    })
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      const added = result.state.dataSpec.groups
+        .find((g) => g.id === 'g2')!
+        .requirements.find((r) => r.label === 'Plain field')
+      expect(added?.control).toBeUndefined()
+      expect(added?.helpText).toBeUndefined()
+    }
+  })
+
   it('removeField deletes a field from its group', () => {
     const result = executeCommand(fixture(), {
       kind: 'removeField',

--- a/test/forms/shaping/executor-fields.test.ts
+++ b/test/forms/shaping/executor-fields.test.ts
@@ -271,4 +271,35 @@ describe('executor — field commands', () => {
     })
     expect(result.ok).toBe(false)
   })
+
+  it('unknown field id error lists known field ids', () => {
+    const result = executeCommand(fixture(), {
+      kind: 'setRequired',
+      id: 'nope',
+      required: true,
+    })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toContain('nope')
+      expect(result.error).toContain('f1')
+      expect(result.error).toContain('f2')
+      expect(result.error).toContain('f3')
+    }
+  })
+
+  it('unknown groupId error lists known group ids', () => {
+    const result = executeCommand(fixture(), {
+      kind: 'addField',
+      groupId: 'missing-group',
+      label: 'X',
+      fieldType: 'text',
+      required: false,
+    })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toContain('missing-group')
+      expect(result.error).toContain('g1')
+      expect(result.error).toContain('g2')
+    }
+  })
 })

--- a/test/forms/shaping/executor-pages.test.ts
+++ b/test/forms/shaping/executor-pages.test.ts
@@ -193,4 +193,19 @@ describe('executor — page commands', () => {
       expect(result.state.formSpec.pages[0].groups).toEqual(['g1', 'g2'])
     }
   })
+
+  it('unknown page id error lists known page ids', () => {
+    const result = executeCommand(fixture(), {
+      kind: 'renamePage',
+      id: 'missing-page',
+      title: 'X',
+    })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toContain('missing-page')
+      expect(result.error).toContain('p1')
+      expect(result.error).toContain('p2')
+      expect(result.error).toContain('p3')
+    }
+  })
 })

--- a/test/forms/shaping/retry.test.ts
+++ b/test/forms/shaping/retry.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'bun:test'
+import type {
+  Command,
+  FormShaper,
+  ProjectState,
+} from '../../../src/services/forms'
+import { withValidationRetry } from '../../../src/services/forms/shaping/retry'
+import type {
+  ShapingRequest,
+  ShapingResult,
+} from '../../../src/services/forms/shaping/types'
+
+function fixture(): ProjectState {
+  return {
+    dataSpec: {
+      id: 'ds1',
+      title: 'T',
+      description: '',
+      groups: [
+        {
+          id: 'g1',
+          title: 'G1',
+          requirements: [
+            {
+              id: 'f1',
+              fieldName: 'name',
+              label: 'Name',
+              fieldType: 'text',
+              required: true,
+            },
+          ],
+        },
+      ],
+    },
+    formSpec: {
+      id: 'form1',
+      specId: 'ds1',
+      title: 'F',
+      pages: [{ id: 'p1', title: 'P', groups: ['g1'] }],
+    },
+  }
+}
+
+function fakeShaper(scripted: Array<Command[] | Error>): {
+  shaper: FormShaper
+  calls: ShapingRequest[]
+} {
+  const calls: ShapingRequest[] = []
+  let idx = 0
+  const shaper: FormShaper = {
+    async shape(request: ShapingRequest): Promise<ShapingResult> {
+      calls.push(request)
+      const step = scripted[idx++]
+      if (step instanceof Error) throw step
+      return { commands: step, explanation: 'ok' }
+    },
+  }
+  return { shaper, calls }
+}
+
+describe('withValidationRetry', () => {
+  it('returns the inner result unchanged when it validates on the first try', async () => {
+    const { shaper, calls } = fakeShaper([
+      [{ kind: 'renamePage', id: 'p1', title: 'New' }],
+    ])
+    const wrapped = withValidationRetry(shaper)
+    const result = await wrapped.shape({ intent: 'rename', state: fixture() })
+    expect(result.commands).toHaveLength(1)
+    expect(calls.length).toBe(1)
+  })
+
+  it('retries once with previousAttempt populated when the first batch is invalid', async () => {
+    const { shaper, calls } = fakeShaper([
+      [{ kind: 'renamePage', id: 'nope', title: 'X' }],
+      [{ kind: 'renamePage', id: 'p1', title: 'X' }],
+    ])
+    const wrapped = withValidationRetry(shaper)
+    const result = await wrapped.shape({ intent: 'rename', state: fixture() })
+    expect(result.commands).toHaveLength(1)
+    expect(calls.length).toBe(2)
+    expect(calls[1].previousAttempt).toBeDefined()
+    expect(calls[1].previousAttempt?.commands).toEqual([
+      { kind: 'renamePage', id: 'nope', title: 'X' },
+    ])
+    expect(calls[1].previousAttempt?.feedback).toContain('nope')
+    expect(calls[1].previousAttempt?.feedback).toContain('p1')
+  })
+
+  it('throws after exhausting retries', async () => {
+    const { shaper, calls } = fakeShaper([
+      [{ kind: 'renamePage', id: 'nope', title: 'X' }],
+      [{ kind: 'renamePage', id: 'still-nope', title: 'Y' }],
+    ])
+    const wrapped = withValidationRetry(shaper, { maxRetries: 1 })
+    await expect(
+      wrapped.shape({ intent: 'rename', state: fixture() }),
+    ).rejects.toThrow(/invalid command sequence/i)
+    expect(calls.length).toBe(2)
+  })
+
+  it('passes a client-supplied previousAttempt through on the first call', async () => {
+    const { shaper, calls } = fakeShaper([
+      [{ kind: 'renamePage', id: 'p1', title: 'ok' }],
+    ])
+    const wrapped = withValidationRetry(shaper)
+    await wrapped.shape({
+      intent: 'rename',
+      state: fixture(),
+      previousAttempt: {
+        commands: [{ kind: 'swapPages', a: 'p1', b: 'nope' }],
+        feedback: 'user said swap was wrong',
+      },
+    })
+    expect(calls[0].previousAttempt?.feedback).toBe('user said swap was wrong')
+  })
+
+  it('propagates errors thrown by the inner shaper without retrying', async () => {
+    const boom = new Error('bedrock exploded')
+    const { shaper, calls } = fakeShaper([boom])
+    const wrapped = withValidationRetry(shaper)
+    await expect(
+      wrapped.shape({ intent: 'rename', state: fixture() }),
+    ).rejects.toThrow('bedrock exploded')
+    expect(calls.length).toBe(1)
+  })
+})


### PR DESCRIPTION
## Context

Attempting the conversational edit `'add a new "confirmation" page at the end with a checkbox'` on a form project failed with:

> `Error: LLM produced invalid command sequence: Unknown field id: confirmation-group_field_0 (command 3)`

The LLM was emitting a valid 4-command sequence (`addPage` → `addGroup` → `addField` → `setFieldControl`) but inventing an id for the new field without passing it to `addField`, then referencing the made-up id in the follow-up command. The sequential validator rejected the 4th command. Nothing told the LLM how to bridge multi-step creates, there was no retry on validation failure, and error messages didn't give the LLM (or humans) enough context to self-correct.

## Changes

- **Prompt hardening** — the shaper prompt now teaches the multi-step id pattern with a worked example, and warns the LLM about control defaults (`boolean` → checkbox, `choice` → radio) so it stops issuing redundant `setFieldControl` commands.
- **`addField` one-shot** — `addField` now accepts optional `control` and `helpText` so the whole "add a checkbox with help text" case collapses into a single command instead of 2-3.
- **`withValidationRetry` wrapper** — new pure wrapper around any `FormShaper`. On validation failure it re-invokes the inner shaper with `previousAttempt` populated (rejected commands + executor error + known-id context). `bedrock-shaper` no longer throws on validation; the wrapper owns that. Wired into every registered shaping variant.
- **Richer executor errors** — every `Unknown X` error now appends the known ids of that type, so both the retry loop and human debugging have enough signal to fix the batch.
- **Multi-step fixtures** — 3 new intents (`add-phone-to-personal`, `add-confirmation-page`, `add-agreement-page`) in the shaping eval suite, plus a new test asserting every fixture's `expectedCommands` actually executes cleanly via `executeBatch` — so a fixture that references a not-yet-created id fails loudly instead of scoring silently wrong.

## Test plan

- [x] `bun run check` passes (lint + types + 1343 tests).
- [x] New fixtures execute end-to-end against the fixture project state.
- [x] `withValidationRetry` unit-tested in isolation: success first try, success on retry with `previousAttempt` populated, failure after `maxRetries`, client-supplied `previousAttempt` passthrough, non-validation errors propagate without retry.
- [x] Executor error messages include the known-id list (unit tests for page / group / field cases).
- [x] Manual smoke: open the same `/edit/import` page and retry `'add a new "confirmation" page at the end with a checkbox'` after deploy.

## Out of scope

- No new Bedrock eval run in CI (scope C from the design).
- No UI changes; error banners just get better messages for free.
- `addPage` / `addGroup` schemas unchanged.