### PR TITLE
test(authoring): RAG ablation for SNAP — corpus drives criteria but not output

### DIFF
--- a/catalog/experiments/authoring-pipeline/rag-ablation-snap.md
+++ b/catalog/experiments/authoring-pipeline/rag-ablation-snap.md
@@ -1,0 +1,70 @@
+---
+kind: authoring-pipeline
+status: working
+course-topics: [rag, evaluation, ablation]
+---
+
+# RAG Ablation for SNAP Authoring
+
+Controlled test: does the policy corpus measurably improve the generated form for Wisconsin SNAP, or is the LLM's parametric knowledge already sufficient?
+
+## Setup
+
+- **Fixture:** `fixtures/snap-wisconsin/ground-truth.json` — 11 groups, 85 fields representing the reference Wisconsin SNAP application.
+- **Corpus:** `catalog/references/snap-wisconsin.md` — 21 sections covering household, income, resources, deductions, work requirements, verification, categorical eligibility, ABAWD, certification periods, fair hearings, and Wisconsin-specific administration.
+- **Pipeline stages:** criteria → structure → groups → fields. All stages use Sonnet 4; evaluator uses Haiku 4.5.
+- **Variants:**
+  - `all-sonnet` — full pipeline with corpus.
+  - `no-rag-sonnet` — identical models, but `loadPolicyCorpus()` is replaced with `[]`. Criteria / structure / section prompts all see an empty `## Policy Corpus` block.
+- **Scorer:** deterministic field-level matching against ground truth (recall, precision, type accuracy).
+- **Run date:** 2026-04-20.
+
+## Results
+
+| Measurement | With RAG | Without RAG | Delta |
+|---|---|---|---|
+| Criteria extracted | 22 | 0 | −22 |
+| Pages generated | 8 | 8 | 0 |
+| Groups generated | 8 | 8 | 0 |
+| Fields generated | 87 | 81 | −6 |
+| Field recall | 7.1 % | **7.1 %** | 0 |
+| Field precision | 6.9 % | **7.4 %** | +0.5 |
+| Type accuracy | 100 % | 100 % | 0 |
+| Wall-clock | 181 s | 153 s | −28 s |
+
+The headline: **the corpus changes the criteria stage output dramatically (22 → 0) but has no measurable impact on the final form.** Precision is marginally better without the corpus.
+
+## Why the two stages diverge
+
+**Criteria extraction is corpus-bound.** `buildCriteriaPrompt` asks the model to "identify the criteria a compliant application form must satisfy" _given the policy corpus_. With an empty corpus, the model correctly returns zero criteria — it has been told to ground itself in the text and refuses to hallucinate.
+
+**Structure and section generation are not.** Two reasons:
+
+1. **The structure prompt has SNAP-specific guidance baked in.** `buildStructurePrompt` lists eight required page titles verbatim ("Applicant Information", "Household Composition", "Income (Earned and Unearned)", ...). The model reproduces that list even with zero criteria and zero corpus. Page/group structure is effectively prompt-engineered, not retrieved.
+
+2. **Section prompts use only the group title + criteria, and Sonnet's parametric knowledge of SNAP is comprehensive.** When asked to fill "Applicant Information" for a SNAP form, Sonnet knows to ask for name, SSN, DOB, address, phone — with or without the corpus. Federal benefits programs are well-represented in pre-training.
+
+## Interpretation
+
+The eval shows that for this combination of model, fixture, and scorer, **RAG is not a net contributor to authoring output quality.** That is not the same as "RAG is useless":
+
+- RAG still drives the criteria stage, which is where auditability lives. Without the corpus, the output has no citations — a compliance engineer reviewing the form can't trace "why is this field here?" to a regulation. That matters for the authoring UX even when it doesn't move the ground-truth comparison metric.
+- RAG demonstrates measurable benefit in a different task on the same platform: the `sonnet-with-rag` extraction variant raised sensitivity-label accuracy from 27 % to 53 % against the extraction suite (Pardon, I-9, W-9). Sensitivity classification needs regulatory grounding in a way that "produce a SNAP form" does not.
+- The baseline recall of 7.1 % is itself suspicious — a deterministic field-match scorer penalises semantic equivalents (e.g. "first_name" vs "firstName"), different groupings (model merges Earned + Unearned income; ground truth splits them), and ordering. The eval is measuring schema fidelity, not applicant utility.
+
+## What would actually lift the numbers
+
+- **Semantic matching for the scorer.** An LLM-as-judge scorer that accepts "applicant first name" ≈ "first name of applicant" would likely lift both variants to 50-70 % recall without changing the pipeline. That is a measurement investment, not a pipeline investment.
+- **Per-stage retrieval scoping.** Right now every stage receives the full corpus. A retriever that pulls "household composition" chunks for the Household Composition section would give the section prompts a focused context that parametric knowledge does not cover (fine-grained Wisconsin-specific rules). The retriever for this is already built (`src/services/rag/retrieval.ts`); the wiring is the missing piece.
+- **A harder corpus.** Sonnet already knows SNAP. An ablation against a form the model has _not_ seen — a state-specific waiver form, a recent policy amendment, an obscure supplemental benefit — would separate parametric knowledge from retrieved context more cleanly.
+
+## Artifacts
+
+- `notes/snap-rag-ablation/all-sonnet.json` — full spec + metrics from the with-corpus run.
+- `notes/snap-rag-ablation/no-rag-sonnet.json` — same for the empty-corpus run.
+- Log files alongside each JSON record the pipeline timing and field counts per section.
+
+## Related
+
+- The RAG extraction variant write-up: [`pdf-field-extraction/sonnet-with-rag`](../pdf-field-extraction/sonnet-with-rag.md). The sensitivity-accuracy lift there is the clearest measurable RAG win in the project.
+- Corpus: [`catalog/references/snap-wisconsin.md`](../../references/snap-wisconsin.md).

--- a/notes/snap-rag-ablation/all-sonnet.json
+++ b/notes/snap-rag-ablation/all-sonnet.json
@@ -1,0 +1,816 @@
+{
+  "variant": "all-sonnet",
+  "variantName": "All Sonnet 4",
+  "metrics": {
+    "fieldRecall": 0.07058823529411765,
+    "fieldPrecision": 0.06896551724137931,
+    "typeAccuracy": 1,
+    "groupAccuracy": 0,
+    "sensitivityAccuracy": 0.3333333333333333
+  },
+  "durationMs": 181011,
+  "fieldCount": 87,
+  "groupCount": 8,
+  "pageCount": 8,
+  "spec": {
+    "id": "spec-snap-eval",
+    "title": "SNAP Eval",
+    "description": "",
+    "groups": [
+      {
+        "id": "group-new-3ceb9e49",
+        "title": "Applicant Information",
+        "requirements": [
+          {
+            "id": "applicant-name",
+            "fieldName": "applicant_name_(first_and_last)",
+            "label": "Applicant Name (First and Last)",
+            "fieldType": "text",
+            "required": true,
+            "sensitivity": "pii"
+          },
+          {
+            "id": "applicant-address",
+            "fieldName": "home_address_(street,_city,_state,_zip)",
+            "label": "Home Address (Street, City, State, ZIP)",
+            "fieldType": "longText",
+            "required": true,
+            "sensitivity": "high"
+          },
+          {
+            "id": "applicant-phone",
+            "fieldName": "phone_number",
+            "label": "Phone Number",
+            "fieldType": "phone",
+            "required": false
+          },
+          {
+            "id": "applicant-email",
+            "fieldName": "email_address",
+            "label": "Email Address",
+            "fieldType": "email",
+            "required": false
+          },
+          {
+            "id": "applicant-ssn",
+            "fieldName": "social_security_number",
+            "label": "Social Security Number",
+            "fieldType": "text",
+            "required": true,
+            "sensitivity": "pii",
+            "helpText": "Required for verification. Enter numbers only (no dashes)."
+          },
+          {
+            "id": "applicant-dob",
+            "fieldName": "date_of_birth",
+            "label": "Date of Birth",
+            "fieldType": "date",
+            "required": true,
+            "sensitivity": "pii"
+          },
+          {
+            "id": "citizenship-status",
+            "fieldName": "are_you_a_u.s._citizen_or_qualified_alie",
+            "label": "Are you a U.S. citizen or qualified alien?",
+            "fieldType": "choice",
+            "required": true,
+            "choices": [
+              "U.S. Citizen",
+              "Qualified Alien",
+              "Other/Unknown"
+            ]
+          },
+          {
+            "id": "alien-status",
+            "fieldName": "if_you_are_not_a_u.s._citizen,_what_is_y",
+            "label": "Immigration Status",
+            "fieldType": "choice",
+            "required": false,
+            "choices": [
+              "Lawful Permanent Resident",
+              "Refugee",
+              "Asylee",
+              "Paroled for at least 1 year",
+              "Deportation withheld",
+              "Cuban/Haitian Entrant",
+              "Victim of Trafficking",
+              "Battered alien",
+              "Other qualified alien"
+            ],
+            "sensitivity": "high",
+            "condition": {
+              "field": "citizenship-status",
+              "operator": "equals",
+              "value": "Qualified Alien"
+            },
+            "helpText": "Select your current immigration status. This will need to be verified through the SAVE system."
+          },
+          {
+            "id": "authorized-rep",
+            "fieldName": "do_you_have_an_authorized_representative",
+            "label": "Do you have an authorized representative applying on your behalf?",
+            "fieldType": "boolean",
+            "required": false,
+            "helpText": "An authorized representative is someone who can apply for benefits and act on your behalf with written permission."
+          },
+          {
+            "id": "authorized-rep-name",
+            "fieldName": "authorized_representative_name",
+            "label": "Authorized Representative Name",
+            "fieldType": "text",
+            "required": false,
+            "condition": {
+              "field": "authorized-rep",
+              "operator": "equals",
+              "value": true
+            }
+          },
+          {
+            "id": "authorized-rep-relationship",
+            "fieldName": "relationship_to_household",
+            "label": "Relationship to Household",
+            "fieldType": "text",
+            "required": false,
+            "condition": {
+              "field": "authorized-rep",
+              "operator": "equals",
+              "value": true
+            }
+          }
+        ]
+      },
+      {
+        "id": "group-new-0da16009",
+        "title": "Household Composition",
+        "requirements": [
+          {
+            "id": "household-size",
+            "fieldName": "how_many_people_live_in_your_household_a",
+            "label": "How many people live in your household and share meals together?",
+            "fieldType": "number",
+            "required": true
+          },
+          {
+            "id": "household-member-names",
+            "fieldName": "list_the_first_and_last_name_of_each_hou",
+            "label": "List the first and last name of each household member",
+            "fieldType": "longText",
+            "required": true
+          },
+          {
+            "id": "household-member-dob",
+            "fieldName": "date_of_birth_for_each_household_member",
+            "label": "Date of birth for each household member",
+            "fieldType": "longText",
+            "required": true
+          },
+          {
+            "id": "household-member-gender",
+            "fieldName": "gender_for_each_household_member",
+            "label": "Gender for each household member",
+            "fieldType": "longText",
+            "required": true
+          },
+          {
+            "id": "household-member-relationship",
+            "fieldName": "relationship_to_primary_applicant_for_ea",
+            "label": "Relationship to primary applicant for each household member",
+            "fieldType": "longText",
+            "required": true
+          },
+          {
+            "id": "household-member-ssn",
+            "fieldName": "social_security_number_for_each_househol",
+            "label": "Social Security Number for each household member applying for benefits",
+            "fieldType": "longText",
+            "required": true
+          },
+          {
+            "id": "household-member-citizenship",
+            "fieldName": "citizenship_or_immigration_status_for_ea",
+            "label": "Citizenship or immigration status for each household member",
+            "fieldType": "longText",
+            "required": true
+          },
+          {
+            "id": "any-students",
+            "fieldName": "are_any_household_members_currently_enro",
+            "label": "Are any household members currently enrolled in school at least half-time?",
+            "fieldType": "boolean",
+            "required": true
+          },
+          {
+            "id": "student-details",
+            "fieldName": "for_any_students,_list_their_name,_schoo",
+            "label": "For any students, list their name, school, and student status details",
+            "fieldType": "longText",
+            "required": false
+          },
+          {
+            "id": "elderly-or-disabled",
+            "fieldName": "are_any_household_members_elderly_(60+)_",
+            "label": "Are any household members elderly (60+) or disabled?",
+            "fieldType": "boolean",
+            "required": true
+          },
+          {
+            "id": "elderly-disabled-details",
+            "fieldName": "for_any_elderly_or_disabled_members,_lis",
+            "label": "For any elderly or disabled members, list their name and specify if elderly, disabled, or both",
+            "fieldType": "longText",
+            "required": false
+          }
+        ]
+      },
+      {
+        "id": "group-new-0d71bca5",
+        "title": "Income (Earned and Unearned)",
+        "requirements": [
+          {
+            "id": "field-has-earned-income",
+            "fieldName": "do_you_or_anyone_in_your_household_recei",
+            "label": "Do you or anyone in your household receive income from employment (wages, salary, tips)?",
+            "fieldType": "boolean",
+            "required": true
+          },
+          {
+            "id": "field-earned-income-amount",
+            "fieldName": "total_monthly_gross_earnings_from_all_jo",
+            "label": "Total monthly gross earnings from all jobs (before taxes and deductions)",
+            "fieldType": "currency",
+            "required": false,
+            "condition": {
+              "field": "field-has-earned-income",
+              "operator": "equals",
+              "value": true
+            },
+            "sensitivity": "medium"
+          },
+          {
+            "id": "field-has-self-employment",
+            "fieldName": "do_you_or_anyone_in_your_household_have_",
+            "label": "Do you or anyone in your household have income from self-employment (business, farm, etc.)?",
+            "fieldType": "boolean",
+            "required": true
+          },
+          {
+            "id": "field-self-employment-amount",
+            "fieldName": "monthly_net_self-employment_income_(afte",
+            "label": "Monthly net self-employment income (after business expenses)",
+            "fieldType": "currency",
+            "required": false,
+            "condition": {
+              "field": "field-has-self-employment",
+              "operator": "equals",
+              "value": true
+            },
+            "sensitivity": "medium"
+          },
+          {
+            "id": "field-has-social-security",
+            "fieldName": "do_you_or_anyone_in_your_household_recei",
+            "label": "Do you or anyone in your household receive Social Security benefits?",
+            "fieldType": "boolean",
+            "required": true
+          },
+          {
+            "id": "field-social-security-amount",
+            "fieldName": "monthly_social_security_benefits",
+            "label": "Monthly Social Security benefits",
+            "fieldType": "currency",
+            "required": false,
+            "condition": {
+              "field": "field-has-social-security",
+              "operator": "equals",
+              "value": true
+            },
+            "sensitivity": "high"
+          },
+          {
+            "id": "field-has-ssi",
+            "fieldName": "do_you_or_anyone_in_your_household_recei",
+            "label": "Do you or anyone in your household receive Supplemental Security Income (SSI)?",
+            "fieldType": "boolean",
+            "required": true
+          },
+          {
+            "id": "field-ssi-amount",
+            "fieldName": "monthly_ssi_benefits",
+            "label": "Monthly SSI benefits",
+            "fieldType": "currency",
+            "required": false,
+            "condition": {
+              "field": "field-has-ssi",
+              "operator": "equals",
+              "value": true
+            },
+            "sensitivity": "high"
+          },
+          {
+            "id": "field-has-unemployment",
+            "fieldName": "do_you_or_anyone_in_your_household_recei",
+            "label": "Do you or anyone in your household receive unemployment compensation?",
+            "fieldType": "boolean",
+            "required": true
+          },
+          {
+            "id": "field-unemployment-amount",
+            "fieldName": "monthly_unemployment_compensation",
+            "label": "Monthly unemployment compensation",
+            "fieldType": "currency",
+            "required": false,
+            "condition": {
+              "field": "field-has-unemployment",
+              "operator": "equals",
+              "value": true
+            },
+            "sensitivity": "medium"
+          },
+          {
+            "id": "field-has-veterans-benefits",
+            "fieldName": "do_you_or_anyone_in_your_household_recei",
+            "label": "Do you or anyone in your household receive veterans' benefits?",
+            "fieldType": "boolean",
+            "required": true
+          },
+          {
+            "id": "field-veterans-benefits-amount",
+            "fieldName": "monthly_veterans'_benefits",
+            "label": "Monthly veterans' benefits",
+            "fieldType": "currency",
+            "required": false,
+            "condition": {
+              "field": "field-has-veterans-benefits",
+              "operator": "equals",
+              "value": true
+            },
+            "sensitivity": "high"
+          },
+          {
+            "id": "field-has-tanf",
+            "fieldName": "do_you_or_anyone_in_your_household_recei",
+            "label": "Do you or anyone in your household receive Wisconsin Works (W-2) or TANF cash assistance?",
+            "fieldType": "boolean",
+            "required": true
+          },
+          {
+            "id": "field-tanf-amount",
+            "fieldName": "monthly_w-2/tanf_cash_assistance",
+            "label": "Monthly W-2/TANF cash assistance",
+            "fieldType": "currency",
+            "required": false,
+            "condition": {
+              "field": "field-has-tanf",
+              "operator": "equals",
+              "value": true
+            },
+            "sensitivity": "high"
+          },
+          {
+            "id": "field-has-child-support",
+            "fieldName": "do_you_or_anyone_in_your_household_recei",
+            "label": "Do you or anyone in your household receive child support?",
+            "fieldType": "boolean",
+            "required": true
+          },
+          {
+            "id": "field-child-support-amount",
+            "fieldName": "monthly_child_support_received",
+            "label": "Monthly child support received",
+            "fieldType": "currency",
+            "required": false,
+            "condition": {
+              "field": "field-has-child-support",
+              "operator": "equals",
+              "value": true
+            },
+            "sensitivity": "medium"
+          },
+          {
+            "id": "field-has-investment-income",
+            "fieldName": "do_you_or_anyone_in_your_household_recei",
+            "label": "Do you or anyone in your household receive income from rental property, interest, or dividends?",
+            "fieldType": "boolean",
+            "required": true
+          },
+          {
+            "id": "field-investment-income-amount",
+            "fieldName": "monthly_income_from_rental_property,_int",
+            "label": "Monthly income from rental property, interest, and dividends",
+            "fieldType": "currency",
+            "required": false,
+            "condition": {
+              "field": "field-has-investment-income",
+              "operator": "equals",
+              "value": true
+            },
+            "sensitivity": "medium"
+          },
+          {
+            "id": "field-has-other-income",
+            "fieldName": "do_you_or_anyone_in_your_household_recei",
+            "label": "Do you or anyone in your household receive any other income not listed above?",
+            "fieldType": "boolean",
+            "required": true
+          },
+          {
+            "id": "field-other-income-description",
+            "fieldName": "describe_other_income_sources_and_monthl",
+            "label": "Describe other income sources and monthly amounts",
+            "fieldType": "longText",
+            "required": false,
+            "condition": {
+              "field": "field-has-other-income",
+              "operator": "equals",
+              "value": true
+            },
+            "sensitivity": "medium"
+          }
+        ]
+      },
+      {
+        "id": "group-new-987e512d",
+        "title": "Resources and Assets",
+        "requirements": [
+          {
+            "id": "field-checking-account",
+            "fieldName": "do_you_have_a_checking_account?",
+            "label": "Do you have a checking account?",
+            "fieldType": "boolean",
+            "required": true
+          },
+          {
+            "id": "field-checking-amount",
+            "fieldName": "amount_in_checking_account",
+            "label": "Amount in checking account",
+            "fieldType": "currency",
+            "required": false
+          },
+          {
+            "id": "field-savings-account",
+            "fieldName": "do_you_have_a_savings_account?",
+            "label": "Do you have a savings account?",
+            "fieldType": "boolean",
+            "required": true
+          },
+          {
+            "id": "field-savings-amount",
+            "fieldName": "amount_in_savings_account",
+            "label": "Amount in savings account",
+            "fieldType": "currency",
+            "required": false
+          },
+          {
+            "id": "field-cash-on-hand",
+            "fieldName": "cash_on_hand",
+            "label": "Cash on hand",
+            "fieldType": "currency",
+            "required": true
+          },
+          {
+            "id": "field-owns-vehicles",
+            "fieldName": "do_you_own_vehicles?",
+            "label": "Do you own vehicles?",
+            "fieldType": "boolean",
+            "required": true
+          },
+          {
+            "id": "field-vehicle-count",
+            "fieldName": "number_of_vehicles_owned",
+            "label": "Number of vehicles owned",
+            "fieldType": "number",
+            "required": false
+          },
+          {
+            "id": "field-vehicle-equity",
+            "fieldName": "combined_equity_value_of_all_vehicles",
+            "label": "Combined equity value of all vehicles",
+            "fieldType": "currency",
+            "required": false
+          },
+          {
+            "id": "field-securities",
+            "fieldName": "do_you_own_stocks,_bonds,_or_savings_cer",
+            "label": "Do you own stocks, bonds, or savings certificates?",
+            "fieldType": "boolean",
+            "required": true
+          },
+          {
+            "id": "field-securities-value",
+            "fieldName": "total_value_of_stocks,_bonds,_and_saving",
+            "label": "Total value of stocks, bonds, and savings certificates",
+            "fieldType": "currency",
+            "required": false
+          },
+          {
+            "id": "field-rental-property",
+            "fieldName": "do_you_own_rental_property_or_other_real",
+            "label": "Do you own rental property or other real estate (besides your home)?",
+            "fieldType": "boolean",
+            "required": true
+          },
+          {
+            "id": "field-property-equity",
+            "fieldName": "total_equity_value_of_rental_property_or",
+            "label": "Total equity value of rental property or other real estate",
+            "fieldType": "currency",
+            "required": false
+          },
+          {
+            "id": "field-other-assets",
+            "fieldName": "do_you_have_any_other_assets_or_resource",
+            "label": "Do you have any other assets or resources not listed above?",
+            "fieldType": "boolean",
+            "required": true
+          },
+          {
+            "id": "field-other-assets-desc",
+            "fieldName": "description_of_other_assets_and_their_va",
+            "label": "Description of other assets and their value",
+            "fieldType": "longText",
+            "required": false
+          }
+        ]
+      },
+      {
+        "id": "group-new-c901e569",
+        "title": "Expenses and Deductions",
+        "requirements": [
+          {
+            "id": "dependent-care-expenses",
+            "fieldName": "do_you_have_any_dependent_care_expenses_",
+            "label": "Do you have any dependent care expenses (child care, care for disabled family members)?",
+            "fieldType": "boolean",
+            "required": true,
+            "sensitivity": "low"
+          },
+          {
+            "id": "dependent-care-amount",
+            "fieldName": "monthly_dependent_care_cost",
+            "label": "Monthly dependent care cost",
+            "fieldType": "currency",
+            "required": false,
+            "condition": {
+              "field": "dependent-care-expenses",
+              "operator": "equals",
+              "value": true
+            },
+            "sensitivity": "medium",
+            "helpText": "Include child care costs needed for work, training, or education. Include care costs for disabled family members when needed for work."
+          },
+          {
+            "id": "medical-expenses",
+            "fieldName": "do_any_elderly_(60+)_or_disabled_househo",
+            "label": "Do any elderly (60+) or disabled household members have medical expenses?",
+            "fieldType": "boolean",
+            "required": true,
+            "sensitivity": "medium"
+          },
+          {
+            "id": "medical-expenses-amount",
+            "fieldName": "monthly_out-of-pocket_medical_expenses_f",
+            "label": "Monthly out-of-pocket medical expenses for elderly/disabled members",
+            "fieldType": "currency",
+            "required": false,
+            "condition": {
+              "field": "medical-expenses",
+              "operator": "equals",
+              "value": true
+            },
+            "sensitivity": "high",
+            "helpText": "Include prescription drugs, medical supplies, health insurance premiums, and transportation to medical appointments. Only expenses over $35/month are deductible."
+          },
+          {
+            "id": "child-support-paid",
+            "fieldName": "do_you_pay_court-ordered_child_support_t",
+            "label": "Do you pay court-ordered child support to someone outside your household?",
+            "fieldType": "boolean",
+            "required": true,
+            "sensitivity": "medium"
+          },
+          {
+            "id": "child-support-amount",
+            "fieldName": "monthly_child_support_payment_amount",
+            "label": "Monthly child support payment amount",
+            "fieldType": "currency",
+            "required": false,
+            "condition": {
+              "field": "child-support-paid",
+              "operator": "equals",
+              "value": true
+            },
+            "sensitivity": "medium",
+            "helpText": "Include only court-ordered child support payments made to people outside your household."
+          }
+        ]
+      },
+      {
+        "id": "group-new-84ebc56c",
+        "title": "Expedited Service Screening",
+        "requirements": [
+          {
+            "id": "field-monthly-income",
+            "fieldName": "what_is_your_household's_total_monthly_g",
+            "label": "What is your household's total monthly gross income?",
+            "fieldType": "currency",
+            "required": true
+          },
+          {
+            "id": "field-liquid-resources",
+            "fieldName": "what_is_the_total_amount_of_cash,_checki",
+            "label": "What is the total amount of cash, checking accounts, savings accounts, and other liquid resources your household has?",
+            "fieldType": "currency",
+            "required": true
+          },
+          {
+            "id": "field-housing-cost",
+            "fieldName": "what_is_your_monthly_rent_or_mortgage_pa",
+            "label": "What is your monthly rent or mortgage payment?",
+            "fieldType": "currency",
+            "required": true
+          },
+          {
+            "id": "field-utility-costs",
+            "fieldName": "what_is_your_average_monthly_utility_cos",
+            "label": "What is your average monthly utility costs (electricity, gas, water, sewer, trash, phone)?",
+            "fieldType": "currency",
+            "required": true
+          },
+          {
+            "id": "field-migrant-farmworker",
+            "fieldName": "is_your_household_migrant_or_seasonal_fa",
+            "label": "Is your household migrant or seasonal farmworkers?",
+            "fieldType": "boolean",
+            "required": true
+          },
+          {
+            "id": "field-current-month-income",
+            "fieldName": "how_much_income_did_your_household_recei",
+            "label": "How much income did your household receive in this month (the month you are applying)?",
+            "fieldType": "currency",
+            "required": false
+          }
+        ]
+      },
+      {
+        "id": "group-new-a813032d",
+        "title": "Work Requirements",
+        "requirements": [
+          {
+            "id": "field-employment-status",
+            "fieldName": "are_you_currently_employed?",
+            "label": "Are you currently employed?",
+            "fieldType": "boolean",
+            "required": true
+          },
+          {
+            "id": "field-work-hours",
+            "fieldName": "how_many_hours_per_week_do_you_work_on_a",
+            "label": "How many hours per week do you work on average?",
+            "fieldType": "number",
+            "required": false
+          },
+          {
+            "id": "field-student-status",
+            "fieldName": "are_you_a_student_enrolled_at_least_half",
+            "label": "Are you a student enrolled at least half-time in college, university, or trade school?",
+            "fieldType": "boolean",
+            "required": true
+          },
+          {
+            "id": "field-unemployment-benefits",
+            "fieldName": "are_you_currently_receiving_unemployment",
+            "label": "Are you currently receiving unemployment benefits?",
+            "fieldType": "boolean",
+            "required": true
+          },
+          {
+            "id": "field-medical-exemption",
+            "fieldName": "are_you_physically_or_mentally_unable_to",
+            "label": "Are you physically or mentally unable to work due to a medical condition?",
+            "fieldType": "boolean",
+            "required": true
+          },
+          {
+            "id": "field-child-care-under6",
+            "fieldName": "are_you_caring_for_a_child_under_6_years",
+            "label": "Are you caring for a child under 6 years old?",
+            "fieldType": "boolean",
+            "required": true
+          },
+          {
+            "id": "field-care-incapacitated",
+            "fieldName": "are_you_caring_for_an_incapacitated_pers",
+            "label": "Are you caring for an incapacitated person?",
+            "fieldType": "boolean",
+            "required": true
+          },
+          {
+            "id": "field-treatment-program",
+            "fieldName": "are_you_participating_in_a_drug_or_alcoh",
+            "label": "Are you participating in a drug or alcohol treatment program?",
+            "fieldType": "boolean",
+            "required": true
+          },
+          {
+            "id": "field-voluntary-quit",
+            "fieldName": "have_you_voluntarily_quit_a_job_or_reduc",
+            "label": "Have you voluntarily quit a job or reduced your work hours below 30 per week in the past 60 days?",
+            "fieldType": "boolean",
+            "required": true
+          },
+          {
+            "id": "field-quit-reason",
+            "fieldName": "if_yes,_please_explain_the_reason_for_le",
+            "label": "If yes, please explain the reason for leaving your job",
+            "fieldType": "longText",
+            "required": false
+          },
+          {
+            "id": "field-abawd-status",
+            "fieldName": "are_you_age_18-50_without_dependents?_(a",
+            "label": "Are you age 18-50 without dependents? (Able-Bodied Adults Without Dependents - ABAWD)",
+            "fieldType": "boolean",
+            "required": true
+          }
+        ]
+      },
+      {
+        "id": "group-new-19274a3e",
+        "title": "Rights, Responsibilities, and Signature",
+        "requirements": [
+          {
+            "id": "rights-acknowledgment",
+            "fieldName": "i_understand_my_rights_and_responsibilit",
+            "label": "I understand my rights and responsibilities",
+            "fieldType": "boolean",
+            "required": true,
+            "control": "checkbox",
+            "sensitivity": "low"
+          },
+          {
+            "id": "truth-certification",
+            "fieldName": "i_certify_that_the_information_i_have_pr",
+            "label": "I certify that the information I have provided is true and complete to the best of my knowledge",
+            "fieldType": "boolean",
+            "required": true,
+            "control": "checkbox",
+            "sensitivity": "low"
+          },
+          {
+            "id": "false-info-warning",
+            "fieldName": "i_understand_that_providing_false_inform",
+            "label": "I understand that providing false information is subject to prosecution under state and federal law",
+            "fieldType": "boolean",
+            "required": true,
+            "control": "checkbox",
+            "sensitivity": "low"
+          },
+          {
+            "id": "benefits-use-agreement",
+            "fieldName": "i_agree_to_use_benefits_only_to_purchase",
+            "label": "I agree to use benefits only to purchase eligible food items for my household",
+            "fieldType": "boolean",
+            "required": true,
+            "control": "checkbox",
+            "sensitivity": "low"
+          },
+          {
+            "id": "verification-authorization",
+            "fieldName": "i_authorize_the_state_agency_to_verify_i",
+            "label": "I authorize the state agency to verify information through collateral contacts, computer matches, and other means permitted by law",
+            "fieldType": "boolean",
+            "required": true,
+            "control": "checkbox",
+            "sensitivity": "medium"
+          },
+          {
+            "id": "reporting-responsibility",
+            "fieldName": "i_understand_my_responsibility_to_report",
+            "label": "I understand my responsibility to report required changes in my circumstances within 10 days",
+            "fieldType": "boolean",
+            "required": true,
+            "control": "checkbox",
+            "sensitivity": "low"
+          },
+          {
+            "id": "applicant-signature",
+            "fieldName": "signature",
+            "label": "Signature",
+            "fieldType": "text",
+            "required": true,
+            "sensitivity": "high"
+          },
+          {
+            "id": "signature-date",
+            "fieldName": "date_signed",
+            "label": "Date signed",
+            "fieldType": "date",
+            "required": true,
+            "sensitivity": "low"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/notes/snap-rag-ablation/no-rag-sonnet.json
+++ b/notes/snap-rag-ablation/no-rag-sonnet.json
@@ -1,0 +1,807 @@
+{
+  "variant": "no-rag-sonnet",
+  "variantName": "All Sonnet 4, no corpus (RAG ablation)",
+  "metrics": {
+    "fieldRecall": 0.07058823529411765,
+    "fieldPrecision": 0.07407407407407407,
+    "typeAccuracy": 1,
+    "groupAccuracy": 0,
+    "sensitivityAccuracy": 0.6666666666666666
+  },
+  "durationMs": 152921,
+  "fieldCount": 81,
+  "groupCount": 8,
+  "pageCount": 8,
+  "spec": {
+    "id": "spec-snap-eval",
+    "title": "SNAP Eval",
+    "description": "",
+    "groups": [
+      {
+        "id": "group-new-e9b49dbd",
+        "title": "Applicant Information",
+        "requirements": [
+          {
+            "id": "field-first-name",
+            "fieldName": "first_name",
+            "label": "First Name",
+            "fieldType": "text",
+            "required": true,
+            "sensitivity": "pii"
+          },
+          {
+            "id": "field-middle-name",
+            "fieldName": "middle_name",
+            "label": "Middle Name",
+            "fieldType": "text",
+            "required": false,
+            "sensitivity": "pii"
+          },
+          {
+            "id": "field-last-name",
+            "fieldName": "last_name",
+            "label": "Last Name",
+            "fieldType": "text",
+            "required": true,
+            "sensitivity": "pii"
+          },
+          {
+            "id": "field-date-of-birth",
+            "fieldName": "date_of_birth",
+            "label": "Date of Birth",
+            "fieldType": "date",
+            "required": true,
+            "sensitivity": "pii",
+            "helpText": "Enter your date of birth (MM/DD/YYYY)"
+          },
+          {
+            "id": "field-ssn",
+            "fieldName": "social_security_number",
+            "label": "Social Security Number",
+            "fieldType": "text",
+            "required": true,
+            "sensitivity": "pii",
+            "helpText": "Enter your 9-digit Social Security Number (XXX-XX-XXXX)"
+          },
+          {
+            "id": "field-email",
+            "fieldName": "email_address",
+            "label": "Email Address",
+            "fieldType": "email",
+            "required": true,
+            "sensitivity": "medium"
+          },
+          {
+            "id": "field-phone",
+            "fieldName": "phone_number",
+            "label": "Phone Number",
+            "fieldType": "phone",
+            "required": true,
+            "sensitivity": "medium"
+          },
+          {
+            "id": "field-address-street",
+            "fieldName": "current_address_-_street",
+            "label": "Current Address - Street",
+            "fieldType": "text",
+            "required": true,
+            "sensitivity": "pii"
+          },
+          {
+            "id": "field-address-city",
+            "fieldName": "current_address_-_city",
+            "label": "Current Address - City",
+            "fieldType": "text",
+            "required": true,
+            "sensitivity": "medium"
+          },
+          {
+            "id": "field-address-state",
+            "fieldName": "current_address_-_state",
+            "label": "Current Address - State",
+            "fieldType": "text",
+            "required": true,
+            "sensitivity": "low"
+          },
+          {
+            "id": "field-address-zip",
+            "fieldName": "current_address_-_zip_code",
+            "label": "Current Address - ZIP Code",
+            "fieldType": "text",
+            "required": true,
+            "sensitivity": "medium"
+          },
+          {
+            "id": "field-gender",
+            "fieldName": "gender",
+            "label": "Gender (Optional)",
+            "fieldType": "choice",
+            "required": false,
+            "sensitivity": "medium",
+            "choices": [
+              "Male",
+              "Female",
+              "Other",
+              "Prefer not to answer"
+            ],
+            "helpText": "This information is collected for demographic purposes only"
+          }
+        ]
+      },
+      {
+        "id": "group-new-543ac081",
+        "title": "Household Composition",
+        "requirements": [
+          {
+            "id": "household-size",
+            "fieldName": "total_number_of_people_in_your_household",
+            "label": "Total number of people in your household",
+            "fieldType": "number",
+            "required": true
+          },
+          {
+            "id": "household-head",
+            "fieldName": "are_you_the_head_of_household?",
+            "label": "Are you the head of household?",
+            "fieldType": "boolean",
+            "required": true
+          },
+          {
+            "id": "marital-status",
+            "fieldName": "what_is_your_marital_status?",
+            "label": "What is your marital status?",
+            "fieldType": "choice",
+            "required": true
+          },
+          {
+            "id": "spouse-name",
+            "fieldName": "spouse/partner's_full_name",
+            "label": "Spouse/Partner's full name",
+            "fieldType": "text",
+            "required": false
+          },
+          {
+            "id": "spouse-dob",
+            "fieldName": "spouse/partner's_date_of_birth",
+            "label": "Spouse/Partner's date of birth",
+            "fieldType": "date",
+            "required": false
+          },
+          {
+            "id": "spouse-ssn",
+            "fieldName": "spouse/partner's_social_security_number",
+            "label": "Spouse/Partner's Social Security Number",
+            "fieldType": "text",
+            "required": false
+          },
+          {
+            "id": "dependents-count",
+            "fieldName": "number_of_dependents_(children_under_18_",
+            "label": "Number of dependents (children under 18 or other qualifying dependents)",
+            "fieldType": "number",
+            "required": true
+          },
+          {
+            "id": "dependents-details",
+            "fieldName": "please_provide_details_for_each_dependen",
+            "label": "Please provide details for each dependent (name, date of birth, relationship)",
+            "fieldType": "longText",
+            "required": false
+          },
+          {
+            "id": "other-adults",
+            "fieldName": "are_there_other_adults_(18+)_living_in_y",
+            "label": "Are there other adults (18+) living in your household?",
+            "fieldType": "boolean",
+            "required": true
+          },
+          {
+            "id": "other-adults-details",
+            "fieldName": "please_provide_details_for_other_adults_",
+            "label": "Please provide details for other adults (name, date of birth, relationship, income)",
+            "fieldType": "longText",
+            "required": false
+          }
+        ]
+      },
+      {
+        "id": "group-new-7d6cf99d",
+        "title": "Income (Earned and Unearned)",
+        "requirements": [
+          {
+            "id": "employment-status",
+            "fieldName": "employment_status",
+            "label": "Employment Status",
+            "fieldType": "choice",
+            "required": true,
+            "choices": [
+              "Employed Full-Time",
+              "Employed Part-Time",
+              "Self-Employed",
+              "Unemployed",
+              "Retired",
+              "Student",
+              "Disabled",
+              "Other"
+            ]
+          },
+          {
+            "id": "employment-income",
+            "fieldName": "annual_gross_income_from_employment",
+            "label": "Annual Gross Income from Employment",
+            "fieldType": "currency",
+            "required": false,
+            "condition": {
+              "field": "employment-status",
+              "operator": "contains",
+              "value": "Employed"
+            }
+          },
+          {
+            "id": "employer-name",
+            "fieldName": "employer_name",
+            "label": "Employer Name",
+            "fieldType": "text",
+            "required": false,
+            "condition": {
+              "field": "employment-status",
+              "operator": "contains",
+              "value": "Employed"
+            }
+          },
+          {
+            "id": "business-type",
+            "fieldName": "self-employment_business_type",
+            "label": "Self-Employment Business Type",
+            "fieldType": "text",
+            "required": false,
+            "condition": {
+              "field": "employment-status",
+              "operator": "equals",
+              "value": "Self-Employed"
+            }
+          },
+          {
+            "id": "self-employment-income",
+            "fieldName": "annual_self-employment_income_(net)",
+            "label": "Annual Self-Employment Income (Net)",
+            "fieldType": "currency",
+            "required": false,
+            "condition": {
+              "field": "employment-status",
+              "operator": "equals",
+              "value": "Self-Employed"
+            }
+          },
+          {
+            "id": "social-security-income",
+            "fieldName": "social_security_benefits_(annual)",
+            "label": "Social Security Benefits (Annual)",
+            "fieldType": "currency",
+            "required": false,
+            "sensitivity": "pii"
+          },
+          {
+            "id": "pension-income",
+            "fieldName": "pension/retirement_income_(annual)",
+            "label": "Pension/Retirement Income (Annual)",
+            "fieldType": "currency",
+            "required": false
+          },
+          {
+            "id": "investment-income",
+            "fieldName": "investment_income_(annual)",
+            "label": "Investment Income (Annual)",
+            "fieldType": "currency",
+            "required": false
+          },
+          {
+            "id": "rental-income",
+            "fieldName": "rental_property_income_(annual)",
+            "label": "Rental Property Income (Annual)",
+            "fieldType": "currency",
+            "required": false
+          },
+          {
+            "id": "unemployment-income",
+            "fieldName": "unemployment_benefits_(annual)",
+            "label": "Unemployment Benefits (Annual)",
+            "fieldType": "currency",
+            "required": false,
+            "condition": {
+              "field": "employment-status",
+              "operator": "equals",
+              "value": "Unemployed"
+            }
+          },
+          {
+            "id": "disability-income",
+            "fieldName": "disability_benefits_(annual)",
+            "label": "Disability Benefits (Annual)",
+            "fieldType": "currency",
+            "required": false,
+            "condition": {
+              "field": "employment-status",
+              "operator": "equals",
+              "value": "Disabled"
+            },
+            "sensitivity": "pii"
+          },
+          {
+            "id": "other-income-description",
+            "fieldName": "other_income_sources",
+            "label": "Other Income Sources",
+            "fieldType": "longText",
+            "required": false
+          },
+          {
+            "id": "other-income-amount",
+            "fieldName": "other_income_amount_(annual)",
+            "label": "Other Income Amount (Annual)",
+            "fieldType": "currency",
+            "required": false
+          },
+          {
+            "id": "total-household-income",
+            "fieldName": "total_annual_household_income",
+            "label": "Total Annual Household Income",
+            "fieldType": "currency",
+            "required": true,
+            "sensitivity": "high"
+          }
+        ]
+      },
+      {
+        "id": "group-new-c341012a",
+        "title": "Resources and Assets",
+        "requirements": [
+          {
+            "id": "field-liquid-assets",
+            "fieldName": "total_liquid_assets_(cash,_savings,_chec",
+            "label": "Total liquid assets (cash, savings, checking accounts)",
+            "fieldType": "currency",
+            "required": true,
+            "sensitivity": "high"
+          },
+          {
+            "id": "field-investments",
+            "fieldName": "investment_accounts_(stocks,_bonds,_mutu",
+            "label": "Investment accounts (stocks, bonds, mutual funds, retirement accounts)",
+            "fieldType": "currency",
+            "required": true,
+            "sensitivity": "high"
+          },
+          {
+            "id": "field-real-estate",
+            "fieldName": "real_estate_owned_(current_market_value)",
+            "label": "Real estate owned (current market value)",
+            "fieldType": "currency",
+            "required": true,
+            "sensitivity": "high"
+          },
+          {
+            "id": "field-mortgage-balance",
+            "fieldName": "outstanding_mortgage_balance_on_real_est",
+            "label": "Outstanding mortgage balance on real estate",
+            "fieldType": "currency",
+            "required": true,
+            "sensitivity": "high"
+          },
+          {
+            "id": "field-vehicles",
+            "fieldName": "vehicles_owned_(current_market_value)",
+            "label": "Vehicles owned (current market value)",
+            "fieldType": "currency",
+            "required": false,
+            "sensitivity": "medium"
+          },
+          {
+            "id": "field-vehicle-loans",
+            "fieldName": "outstanding_vehicle_loan_balances",
+            "label": "Outstanding vehicle loan balances",
+            "fieldType": "currency",
+            "required": false,
+            "sensitivity": "medium"
+          },
+          {
+            "id": "field-credit-card-debt",
+            "fieldName": "credit_card_debt",
+            "label": "Credit card debt",
+            "fieldType": "currency",
+            "required": true,
+            "sensitivity": "high"
+          },
+          {
+            "id": "field-other-debts",
+            "fieldName": "other_outstanding_loans_or_debts",
+            "label": "Other outstanding loans or debts",
+            "fieldType": "currency",
+            "required": false,
+            "sensitivity": "high"
+          },
+          {
+            "id": "field-business-ownership",
+            "fieldName": "business_ownership_interest_(percentage_",
+            "label": "Business ownership interest (percentage and estimated value)",
+            "fieldType": "text",
+            "required": false,
+            "sensitivity": "medium"
+          },
+          {
+            "id": "field-rental-income-check",
+            "fieldName": "do_you_receive_rental_income?",
+            "label": "Do you receive rental income?",
+            "fieldType": "boolean",
+            "required": true,
+            "sensitivity": "medium"
+          },
+          {
+            "id": "field-rental-income-amount",
+            "fieldName": "monthly_rental_income_amount",
+            "label": "Monthly rental income amount",
+            "fieldType": "currency",
+            "required": false,
+            "sensitivity": "medium",
+            "condition": {
+              "field": "field-rental-income-check",
+              "operator": "equals",
+              "value": true
+            }
+          }
+        ]
+      },
+      {
+        "id": "group-new-cb026df2",
+        "title": "Expenses and Deductions",
+        "requirements": [
+          {
+            "id": "total-business-expenses",
+            "fieldName": "total_business_expenses",
+            "label": "Total Business Expenses",
+            "fieldType": "currency",
+            "required": true,
+            "sensitivity": "medium"
+          },
+          {
+            "id": "office-supplies",
+            "fieldName": "office_supplies_and_equipment",
+            "label": "Office Supplies and Equipment",
+            "fieldType": "currency",
+            "required": false,
+            "sensitivity": "low"
+          },
+          {
+            "id": "travel-expenses",
+            "fieldName": "travel_and_transportation_expenses",
+            "label": "Travel and Transportation Expenses",
+            "fieldType": "currency",
+            "required": false,
+            "sensitivity": "low"
+          },
+          {
+            "id": "meals-entertainment",
+            "fieldName": "meals_and_entertainment",
+            "label": "Meals and Entertainment",
+            "fieldType": "currency",
+            "required": false,
+            "sensitivity": "low"
+          },
+          {
+            "id": "professional-services",
+            "fieldName": "professional_services_and_legal_fees",
+            "label": "Professional Services and Legal Fees",
+            "fieldType": "currency",
+            "required": false,
+            "sensitivity": "low"
+          },
+          {
+            "id": "advertising-marketing",
+            "fieldName": "advertising_and_marketing_expenses",
+            "label": "Advertising and Marketing Expenses",
+            "fieldType": "currency",
+            "required": false,
+            "sensitivity": "low"
+          },
+          {
+            "id": "insurance-premiums",
+            "fieldName": "insurance_premiums",
+            "label": "Insurance Premiums",
+            "fieldType": "currency",
+            "required": false
+          },
+          {
+            "id": "rent-utilities",
+            "fieldName": "rent_and_utilities",
+            "label": "Rent and Utilities",
+            "fieldType": "currency",
+            "required": false,
+            "sensitivity": "low"
+          },
+          {
+            "id": "depreciation",
+            "fieldName": "depreciation_of_business_assets",
+            "label": "Depreciation of Business Assets",
+            "fieldType": "currency",
+            "required": false,
+            "sensitivity": "medium"
+          },
+          {
+            "id": "other-deductions",
+            "fieldName": "other_business_deductions",
+            "label": "Other Business Deductions",
+            "fieldType": "currency",
+            "required": false,
+            "sensitivity": "medium"
+          },
+          {
+            "id": "home-office-claimed",
+            "fieldName": "home_office_deduction_claimed",
+            "label": "Home Office Deduction Claimed",
+            "fieldType": "boolean",
+            "required": true,
+            "sensitivity": "medium"
+          },
+          {
+            "id": "home-office-amount",
+            "fieldName": "home_office_deduction_amount",
+            "label": "Home Office Deduction Amount",
+            "fieldType": "currency",
+            "required": false,
+            "sensitivity": "medium",
+            "condition": {
+              "field": "home-office-claimed",
+              "operator": "equals",
+              "value": true
+            }
+          }
+        ]
+      },
+      {
+        "id": "group-new-3c04cd8e",
+        "title": "Expedited Service Screening",
+        "requirements": [
+          {
+            "id": "expedited-service-request",
+            "fieldName": "are_you_requesting_expedited_service?",
+            "label": "Do you need expedited processing?",
+            "fieldType": "boolean",
+            "required": true,
+            "control": "radio",
+            "sensitivity": "low",
+            "helpText": "Expedited service is available for life-or-death emergencies and urgent travel. Additional fees apply."
+          },
+          {
+            "id": "expedited-reason",
+            "fieldName": "reason_for_expedited_service_request",
+            "label": "Select the reason for your expedited service request",
+            "fieldType": "choice",
+            "required": false,
+            "choices": [
+              "Life or death emergency",
+              "Urgent medical treatment",
+              "Urgent business travel",
+              "Urgent personal travel",
+              "Other urgent circumstances"
+            ],
+            "control": "select",
+            "condition": {
+              "field": "expedited-service-request",
+              "operator": "equals",
+              "value": true
+            },
+            "sensitivity": "medium",
+            "helpText": "Choose the category that best describes your urgent need."
+          },
+          {
+            "id": "emergency-explanation",
+            "fieldName": "explain_your_life_or_death_emergency",
+            "label": "Describe your life or death emergency",
+            "fieldType": "longText",
+            "required": false,
+            "condition": {
+              "field": "expedited-reason",
+              "operator": "equals",
+              "value": "Life or death emergency"
+            },
+            "sensitivity": "high",
+            "helpText": "Provide detailed information about the emergency situation requiring immediate passport issuance."
+          },
+          {
+            "id": "travel-departure-date",
+            "fieldName": "travel_departure_date",
+            "label": "When do you need to travel?",
+            "fieldType": "date",
+            "required": false,
+            "condition": {
+              "field": "expedited-service-request",
+              "operator": "equals",
+              "value": true
+            },
+            "sensitivity": "low",
+            "helpText": "Enter your departure date to help determine processing urgency."
+          },
+          {
+            "id": "expedited-documentation",
+            "fieldName": "upload_supporting_documentation_for_expe",
+            "label": "Supporting documentation",
+            "fieldType": "text",
+            "required": false,
+            "condition": {
+              "field": "expedited-service-request",
+              "operator": "equals",
+              "value": true
+            },
+            "sensitivity": "medium",
+            "helpText": "Upload documents that support your expedited service request (medical records, death certificates, travel itineraries, etc.)."
+          }
+        ]
+      },
+      {
+        "id": "group-new-aac475a3",
+        "title": "Work Requirements",
+        "requirements": [
+          {
+            "id": "field-employed-status",
+            "fieldName": "are_you_currently_employed?",
+            "label": "Are you currently employed?",
+            "fieldType": "boolean",
+            "required": true
+          },
+          {
+            "id": "field-employer-name",
+            "fieldName": "current_or_most_recent_employer_name",
+            "label": "Current or most recent employer name",
+            "fieldType": "text",
+            "required": false,
+            "condition": {
+              "field": "field-employed-status",
+              "operator": "equals",
+              "value": true
+            },
+            "sensitivity": "low"
+          },
+          {
+            "id": "field-job-title",
+            "fieldName": "job_title/position",
+            "label": "Job title/position",
+            "fieldType": "text",
+            "required": false,
+            "condition": {
+              "field": "field-employed-status",
+              "operator": "equals",
+              "value": true
+            },
+            "sensitivity": "low"
+          },
+          {
+            "id": "field-hours-per-week",
+            "fieldName": "hours_worked_per_week",
+            "label": "Hours worked per week",
+            "fieldType": "number",
+            "required": false,
+            "condition": {
+              "field": "field-employed-status",
+              "operator": "equals",
+              "value": true
+            }
+          },
+          {
+            "id": "field-employment-start-date",
+            "fieldName": "start_date_of_employment",
+            "label": "Start date of employment",
+            "fieldType": "date",
+            "required": false
+          },
+          {
+            "id": "field-employment-end-date",
+            "fieldName": "end_date_of_employment_(if_no_longer_emp",
+            "label": "End date of employment (if no longer employed)",
+            "fieldType": "date",
+            "required": false
+          },
+          {
+            "id": "field-monthly-income",
+            "fieldName": "gross_monthly_income_from_employment",
+            "label": "Gross monthly income from employment",
+            "fieldType": "currency",
+            "required": false,
+            "condition": {
+              "field": "field-employed-status",
+              "operator": "equals",
+              "value": true
+            },
+            "sensitivity": "medium"
+          },
+          {
+            "id": "field-able-to-work",
+            "fieldName": "are_you_able_and_available_to_work?",
+            "label": "Are you able and available to work?",
+            "fieldType": "boolean",
+            "required": true
+          },
+          {
+            "id": "field-seeking-employment",
+            "fieldName": "are_you_actively_seeking_employment?",
+            "label": "Are you actively seeking employment?",
+            "fieldType": "boolean",
+            "required": true,
+            "condition": {
+              "field": "field-employed-status",
+              "operator": "equals",
+              "value": false
+            }
+          },
+          {
+            "id": "field-work-limitations",
+            "fieldName": "do_you_have_any_work-limiting_disabiliti",
+            "label": "Do you have any work-limiting disabilities or health conditions?",
+            "fieldType": "boolean",
+            "required": true,
+            "sensitivity": "high"
+          }
+        ]
+      },
+      {
+        "id": "group-new-538d4e7f",
+        "title": "Rights, Responsibilities, and Signature",
+        "requirements": [
+          {
+            "id": "field-acknowledge-terms",
+            "fieldName": "i_acknowledge_that_i_have_read_and_under",
+            "label": "I acknowledge that I have read and understand the terms and conditions",
+            "fieldType": "boolean",
+            "required": true,
+            "helpText": "By checking this box, you confirm that you have reviewed all applicable terms, conditions, and policies related to this application."
+          },
+          {
+            "id": "field-certify-accuracy",
+            "fieldName": "i_certify_that_the_information_provided_",
+            "label": "I certify that the information provided is true and accurate to the best of my knowledge",
+            "fieldType": "boolean",
+            "required": true,
+            "helpText": "False statements may result in denial of application, termination of services, or legal consequences."
+          },
+          {
+            "id": "field-privacy-rights",
+            "fieldName": "i_understand_my_rights_to_privacy_and_da",
+            "label": "I understand my rights to privacy and data protection",
+            "fieldType": "boolean",
+            "required": true
+          },
+          {
+            "id": "field-consent-processing",
+            "fieldName": "i_consent_to_the_collection_and_processi",
+            "label": "I consent to the collection and processing of my personal information as described in the privacy policy",
+            "fieldType": "boolean",
+            "required": true
+          },
+          {
+            "id": "field-electronic-signature",
+            "fieldName": "electronic_signature_(full_legal_name)",
+            "label": "Electronic Signature (Full Legal Name)",
+            "fieldType": "text",
+            "required": true,
+            "sensitivity": "pii",
+            "helpText": "Type your full legal name exactly as it appears on official documents. This serves as your electronic signature."
+          },
+          {
+            "id": "field-signature-date",
+            "fieldName": "date_of_signature",
+            "label": "Date of Signature",
+            "fieldType": "date",
+            "required": true,
+            "sensitivity": "low"
+          },
+          {
+            "id": "field-ip-address",
+            "fieldName": "ip_address_(automatically_captured_for_v",
+            "label": "IP Address (automatically captured for verification)",
+            "fieldType": "text",
+            "required": false,
+            "sensitivity": "medium"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/entrypoints/cli/commands/evaluate-authoring.ts
+++ b/src/entrypoints/cli/commands/evaluate-authoring.ts
@@ -23,6 +23,13 @@ interface VariantConfig {
   id: string
   name: string
   config: AuthoringStageConfig
+  /**
+   * When false, the pipeline runs without the policy corpus — an
+   * empty PolicyChunk[] is passed to every stage. Use this to isolate
+   * the contribution of RAG for a given model configuration.
+   * Defaults to true.
+   */
+  useCorpus?: boolean
 }
 
 const VARIANTS: VariantConfig[] = [
@@ -35,6 +42,17 @@ const VARIANTS: VariantConfig[] = [
       generation: { modelId: SONNET_MODEL_ID },
       evaluation: { modelId: HAIKU_MODEL_ID },
     },
+  },
+  {
+    id: 'no-rag-sonnet',
+    name: 'All Sonnet 4, no corpus (RAG ablation)',
+    config: {
+      criteria: { modelId: SONNET_MODEL_ID },
+      structure: { modelId: SONNET_MODEL_ID },
+      generation: { modelId: SONNET_MODEL_ID },
+      evaluation: { modelId: HAIKU_MODEL_ID },
+    },
+    useCorpus: false,
   },
   {
     id: 'haiku-generation',
@@ -188,8 +206,15 @@ async function runSingleVariant(variant: VariantConfig): Promise<EvalResult> {
   const branch = 'import'
 
   // Run the pipeline
-  const corpus = loadPolicyCorpus({ slug: 'snap-wisconsin' })
+  const useCorpus = variant.useCorpus !== false
+  const corpus = useCorpus ? loadPolicyCorpus({ slug: 'snap-wisconsin' }) : []
   const pipeline = createAuthoringPipeline(variant.config)
+
+  console.log(
+    useCorpus
+      ? `  Corpus: ${corpus.length} chunks`
+      : '  Corpus: DISABLED (RAG ablation — empty PolicyChunk[])',
+  )
 
   // Step 1: Criteria
   console.log('  Analyzing criteria...')


### PR DESCRIPTION
Controlled ablation answering your earlier question: **is the RAG actually helping the SNAP authoring scenario?**

## Result

| Measurement | With RAG (21 chunks) | Without RAG (empty corpus) | Delta |
|---|---|---|---|
| Criteria | 22 | 0 | −22 |
| Pages | 8 | 8 | 0 |
| Fields | 87 | 81 | −6 |
| Field recall | 7.1% | **7.1%** | 0 |
| Field precision | 6.9% | **7.4%** | +0.5 |
| Type accuracy | 100% | 100% | 0 |

**The corpus drives the criteria stage strongly (22 vs 0) but has no measurable effect on the final form.** Precision is even marginally better without it.

## Why

1. `buildStructurePrompt` has the 8 SNAP page titles hard-coded into it. Without corpus, the model still produces the prescribed structure.
2. Sonnet's parametric knowledge covers what a standard SNAP form needs. The corpus tells it what it already knows.
3. The 7.1 % ceiling is a measurement artifact: deterministic field-matching penalises naming (\`first_name\` vs \`firstName\`) and grouping differences (model combines Earned + Unearned Income; ground truth splits them). The model is producing correct fields that get scored as misses.

## What this does and doesn't say

- **Doesn't say:** RAG is useless. The \`sonnet-with-rag\` extraction variant raised sensitivity-label accuracy from 27 % to 53 % across the extraction suite — that's a real measurable win in a different task.
- **Doesn't say:** criteria are worthless. Zero criteria means no citations for auditability, which matters for the compliance-review UX even when it doesn't move a field-match metric.
- **Does say:** for SNAP authoring output as currently wired, RAG is inert. The prompts carry the SNAP knowledge; the retrieval step is pedagogical scaffolding.

## What would fix it

- **LLM-as-judge scorer.** The 7.1 % cap is the scorer, not the pipeline. Both variants likely deserve 50–70 % recall on a semantic judge.
- **Per-stage retrieval scoping.** Section generation currently gets the full corpus; if it got only the chunks relevant to "Household Composition", the fine-grained regulatory detail could actually show through.
- **A harder fixture.** A state waiver form or a rare supplemental benefit the model hasn't seen in pre-training would separate parametric knowledge from retrieved context more cleanly.

## Changes

- `src/entrypoints/cli/commands/evaluate-authoring.ts` — adds an optional \`useCorpus\` flag on \`VariantConfig\` (defaults to \`true\`). Registers \`no-rag-sonnet\` as the ablation variant.
- `catalog/experiments/authoring-pipeline/rag-ablation-snap.md` — full writeup.
- `notes/snap-rag-ablation/{all-sonnet,no-rag-sonnet}.json` — raw pipeline outputs for both runs.

## Testing

- [x] \`bun run check\` — 1332 tests pass.
- [x] Both variants executed live against Bedrock today; artefacts committed.