### PR TITLE
feat(authoring): per-project corpus association + form description in UI

### DIFF
--- a/catalog/references/snap-wisconsin.md
+++ b/catalog/references/snap-wisconsin.md
@@ -1,8 +1,10 @@
 ---
 status: stable
 formSlug: snap-wisconsin
-title: Wisconsin SNAP Application (7 CFR 273)
+title: Wisconsin FoodShare (SNAP) Application
 source: 7 CFR 273 — Supplemental Nutrition Assistance Program
+formName: Wisconsin FoodShare (SNAP) Application
+formDescription: Wisconsin's FoodShare program is the state implementation of the federal Supplemental Nutrition Assistance Program (SNAP). Applicants provide household, income, resource, and expense information to determine eligibility for monthly food-purchase benefits delivered via a QUEST EBT card. Governed by 7 CFR 273 with Wisconsin-specific rules under Wis. Stat. 49.79 and Wis. Admin. Code DHS 1507.
 ---
 
 # Wisconsin SNAP Application — Policy Excerpts

--- a/src/entrypoints/app/routes/owner/components.tsx
+++ b/src/entrypoints/app/routes/owner/components.tsx
@@ -130,6 +130,20 @@ export const ProfilePage: FC<{
 // 2. ProjectOverview
 // ---------------------------------------------------------------------------
 
+/**
+ * Metadata about a project's policy corpus. When present on
+ * ProjectOverview the page renders a short callout identifying the
+ * source corpus and summarising the form being built. Routes should
+ * resolve this from the RAG service's `getCorpusMetadata(slug)` so
+ * the presentation layer stays stateless.
+ */
+export interface ProjectCorpusInfo {
+  slug: string
+  formName: string
+  formDescription: string
+  source: string
+}
+
 export const ProjectOverview: FC<{
   view: ProjectView
   owner: string
@@ -139,6 +153,7 @@ export const ProjectOverview: FC<{
   branches?: BranchEntry[]
   branch?: string
   extractionBadge?: { variantId: string; variantName: string } | null
+  corpus?: ProjectCorpusInfo | null
 }> = ({
   view,
   owner,
@@ -148,6 +163,7 @@ export const ProjectOverview: FC<{
   branches,
   branch = 'main',
   extractionBadge,
+  corpus,
 }) => {
   const {
     project,
@@ -259,6 +275,27 @@ export const ProjectOverview: FC<{
       </header>
 
       <RepoNav owner={owner} slug={project.slug} current="overview" />
+
+      {corpus && (
+        <aside
+          class="l-stack"
+          style="gap: var(--flex-space-xs); padding: var(--flex-space-md); border: 1px solid var(--flex-color-border); border-radius: var(--flex-radius-md); background: var(--flex-color-primary-lighter);"
+        >
+          <div
+            class="l-cluster"
+            style="gap: var(--flex-space-sm); align-items: baseline;"
+          >
+            <strong>Form:</strong>
+            <span>{corpus.formName}</span>
+            <span class="text-muted text-sm">&middot; built from corpus</span>
+            <code class="flex-mono text-sm">{corpus.slug}</code>
+            <span class="text-muted text-sm">&middot; {corpus.source}</span>
+          </div>
+          {corpus.formDescription && (
+            <p style="margin: 0;">{corpus.formDescription}</p>
+          )}
+        </aside>
+      )}
 
       {branches && branches.length > 1 && (
         <BranchSwitcher
@@ -922,15 +959,22 @@ export const ErrorPage: FC<{
 // 8. NewProjectPage (updated for /:owner URL structure)
 // ---------------------------------------------------------------------------
 
+export interface CorpusChoice {
+  slug: string
+  formName: string
+  formDescription: string
+}
+
 export const NewProjectPage: FC<{
   fixtures: DemoFixture[]
+  corpora: CorpusChoice[]
   extractionVariant: {
     name: string
     description: string
     evaluationSummary: string
     catalogHref: string
   }
-}> = ({ fixtures, extractionVariant }) => (
+}> = ({ fixtures, corpora, extractionVariant }) => (
   <div class="l-stack">
     <h1>New Project</h1>
 
@@ -960,21 +1004,28 @@ export const NewProjectPage: FC<{
       </div>
     </section>
 
-    <section class="l-stack">
-      <h2>Create from corpus (no PDF)</h2>
-      <form method="post" action={resolveUrl('/new')}>
-        <input type="hidden" name="corpus" value="snap-wisconsin" />
-        <button type="submit" class="flex-card fixture-card">
-          <div class="l-stack" style="gap: var(--flex-space-2xs);">
-            <strong>Build from SNAP Policy Corpus</strong>
-            <span class="text-muted text-sm">
-              Create a Wisconsin SNAP application form from scratch using the
-              policy corpus and RAG-powered authoring pipeline.
-            </span>
-          </div>
-        </button>
-      </form>
-    </section>
+    {corpora.length > 0 && (
+      <section class="l-stack">
+        <h2>Create from policy corpus (no PDF)</h2>
+        <p class="text-muted text-sm">
+          Build a form from a curated regulatory corpus using the RAG-driven
+          authoring pipeline. Each corpus covers a specific government form.
+        </p>
+        <div class="l-grid">
+          {corpora.map((c) => (
+            <form method="post" action={resolveUrl('/new')}>
+              <input type="hidden" name="corpus" value={c.slug} />
+              <button type="submit" class="flex-card fixture-card">
+                <div class="l-stack" style="gap: var(--flex-space-2xs);">
+                  <strong>{c.formName}</strong>
+                  <span class="text-muted text-sm">{c.formDescription}</span>
+                </div>
+              </button>
+            </form>
+          ))}
+        </div>
+      </section>
+    )}
 
     <section class="l-stack">
       <h2>Upload your own PDF</h2>

--- a/src/entrypoints/app/routes/owner/edit/authoring.tsx
+++ b/src/entrypoints/app/routes/owner/edit/authoring.tsx
@@ -61,6 +61,28 @@ export function createAuthoringRoutes(
     return parseCriteriaSet(buf.toString())
   }
 
+  /**
+   * Resolve the policy corpus slug for a project. Authoring routes
+   * should fail fast when the project has no corpus association
+   * rather than silently defaulting to SNAP — every other outcome
+   * hides a data-model bug.
+   */
+  async function requireProjectCorpusSlug(
+    owner: string,
+    slug: string,
+    user: SessionUser,
+    branch: string,
+  ): Promise<string> {
+    const view = await service.getProject(owner, slug, user, branch)
+    const corpusSlug = view.project.corpusSlug
+    if (!corpusSlug) {
+      throw new Error(
+        `Project "${slug}" has no associated policy corpus. Authoring requires a corpus-based project — create one from /new using a "Build from corpus" button.`,
+      )
+    }
+    return corpusSlug
+  }
+
   async function runBuild(
     owner: string,
     slug: string,
@@ -108,13 +130,23 @@ export function createAuthoringRoutes(
         `Models: criteria=${criteriaModelId.split('.').pop()}, structure=${structureModelId.split('.').pop()}, generation=${generationModelId.split('.').pop()}`,
       )
 
+      // Every stage in this build uses the same corpus; resolve the
+      // slug once from the project.
+      const corpusSlug = await requireProjectCorpusSlug(
+        owner,
+        slug,
+        user,
+        branch,
+      )
+      log(`Corpus: ${corpusSlug}`)
+
       // Step 1: Analyze criteria if needed
       const existingCriteria = await loadCriteria(owner, slug, branch)
       let criteriaSet = existingCriteria
 
       if (criteriaSet.criteria.length === 0) {
         log('Analyzing policy corpus...')
-        const corpus = loadPolicyCorpus({ slug: 'snap-wisconsin' })
+        const corpus = loadPolicyCorpus({ slug: corpusSlug })
         const criteriaList = await pipeline.analyzeCriteria(corpus)
         criteriaSet = {
           criteria: criteriaList,
@@ -149,7 +181,7 @@ export function createAuthoringRoutes(
 
       // Step 3: Generate structure (pages only)
       log('Generating page structure (~20s)...')
-      const corpus = loadPolicyCorpus({ slug: 'snap-wisconsin' })
+      const corpus = loadPolicyCorpus({ slug: corpusSlug })
 
       const view = await service.getProject(owner, slug, user, branch)
       const state =
@@ -358,8 +390,14 @@ export function createAuthoringRoutes(
           SONNET_MODEL_ID,
         )
 
-        // Load corpus and analyze
-        const corpus = loadPolicyCorpus({ slug: 'snap-wisconsin' })
+        // Load corpus for this project and analyze
+        const corpusSlug = await requireProjectCorpusSlug(
+          owner,
+          slug,
+          user,
+          branch,
+        )
+        const corpus = loadPolicyCorpus({ slug: corpusSlug })
         const criteriaList = await pipeline.analyzeCriteria(corpus)
 
         const criteria: CriteriaSet = {
@@ -503,7 +541,11 @@ export function createAuthoringRoutes(
       }
 
       const criteria = await loadCriteria(owner, slug, branch)
-      const corpus = await loadPolicyCorpus({ slug: 'snap-wisconsin' })
+      const corpusSlug = view.project.corpusSlug
+      if (!corpusSlug) {
+        return c.json({ error: 'project has no associated policy corpus' }, 400)
+      }
+      const corpus = loadPolicyCorpus({ slug: corpusSlug })
 
       const state =
         view.formSpec && view.spec
@@ -569,7 +611,13 @@ export function createAuthoringRoutes(
           groupTitle: string
         }
         const criteriaSet = await loadCriteria(owner, slug, branch)
-        const corpus = await loadPolicyCorpus({ slug: 'snap-wisconsin' })
+        if (!view.project.corpusSlug) {
+          return c.json(
+            { error: 'project has no associated policy corpus' },
+            400,
+          )
+        }
+        const corpus = loadPolicyCorpus({ slug: view.project.corpusSlug })
 
         const cacheKey = `section:${slug}:${branch}:${body.groupId}`
         if (llmCache.has(cacheKey)) {
@@ -630,7 +678,13 @@ export function createAuthoringRoutes(
 
         const body = (await c.req.json()) as { groupId: string }
         const criteriaSet = await loadCriteria(owner, slug, branch)
-        const corpus = await loadPolicyCorpus({ slug: 'snap-wisconsin' })
+        if (!view.project.corpusSlug) {
+          return c.json(
+            { error: 'project has no associated policy corpus' },
+            400,
+          )
+        }
+        const corpus = loadPolicyCorpus({ slug: view.project.corpusSlug })
 
         const state = {
           formSpec: view.formSpec as unknown as ProjectState['formSpec'],

--- a/src/entrypoints/app/routes/owner/edit/index.tsx
+++ b/src/entrypoints/app/routes/owner/edit/index.tsx
@@ -133,12 +133,18 @@ export function createEditRoutes(
           hasPages,
           uncoveredGroupCount,
         })
-        const corpus = loadPolicyCorpus({ slug: 'snap-wisconsin' })
-        authoringCorpus = corpus.map((c) => ({
-          source: c.source,
-          title: c.title,
-          text: c.text,
-        }))
+        // Preview panel only — if the project has no corpus
+        // association, the authoring pipeline can't run anyway, so
+        // leave the corpus preview empty rather than falling back to
+        // an arbitrary default.
+        if (view.project.corpusSlug) {
+          const corpus = loadPolicyCorpus({ slug: view.project.corpusSlug })
+          authoringCorpus = corpus.map((c) => ({
+            source: c.source,
+            title: c.title,
+            text: c.text,
+          }))
+        }
       } catch {
         // Not an authoring project — no stage indicator shown
       }

--- a/src/entrypoints/app/routes/owner/index.tsx
+++ b/src/entrypoints/app/routes/owner/index.tsx
@@ -3,6 +3,7 @@ import type { ContentfulStatusCode } from 'hono/utils/http-status'
 import { Layout } from '../../../../design-system/components/flex-layout'
 import type { UserStore } from '../../../../services/auth'
 import type { ProjectService } from '../../../../services/projects'
+import { getCorpusMetadata } from '../../../../services/rag'
 import { resolveVariantBadge } from '../../../../services/variant-preferences'
 import { resolveUrl } from '../../../../shared/base-path'
 import { AppError, UnauthenticatedError } from '../../../../shared/errors'
@@ -100,6 +101,17 @@ export function createOwnerRoutes(
             extractionProvenance.variantId,
           )
         : null
+      const corpusMetadata = view.project.corpusSlug
+        ? getCorpusMetadata(view.project.corpusSlug)
+        : null
+      const corpus = corpusMetadata
+        ? {
+            slug: corpusMetadata.slug,
+            formName: corpusMetadata.formName,
+            formDescription: corpusMetadata.formDescription ?? '',
+            source: corpusMetadata.source,
+          }
+        : null
       return c.html(
         <Layout user={user}>
           <ProjectOverview
@@ -110,6 +122,7 @@ export function createOwnerRoutes(
             branches={branches}
             branch={branch}
             extractionBadge={extractionBadge}
+            corpus={corpus}
           />
         </Layout>,
       )
@@ -183,6 +196,17 @@ export function createOwnerRoutes(
             extractionProvenance.variantId,
           )
         : null
+      const corpusMetadata = view.project.corpusSlug
+        ? getCorpusMetadata(view.project.corpusSlug)
+        : null
+      const corpus = corpusMetadata
+        ? {
+            slug: corpusMetadata.slug,
+            formName: corpusMetadata.formName,
+            formDescription: corpusMetadata.formDescription ?? '',
+            source: corpusMetadata.source,
+          }
+        : null
       return c.html(
         <Layout user={user}>
           <ProjectOverview
@@ -191,6 +215,7 @@ export function createOwnerRoutes(
             user={user}
             viewingSha={sha}
             extractionBadge={extractionBadge}
+            corpus={corpus}
           />
         </Layout>,
       )

--- a/src/entrypoints/app/server.tsx
+++ b/src/entrypoints/app/server.tsx
@@ -36,6 +36,7 @@ import {
   createFormProjectRepo,
   createProjectService,
 } from '../../services/projects'
+import { getCorpusMetadata, listCorpora } from '../../services/rag'
 import { createCacheStore, createProjectStore } from '../../services/storage'
 import {
   createVariantPreferencesGateway,
@@ -330,6 +331,24 @@ function getExtractionVariantForCallout(userLogin: string) {
   }
 }
 
+/**
+ * Build the list of corpus-based form choices the New Project page
+ * offers. Only corpora that declare a formDescription (i.e. have
+ * opted into authoring) appear — extraction-only corpora stay out of
+ * the picker.
+ */
+function getCorporaForPicker(): Array<{
+  slug: string
+  formName: string
+  formDescription: string
+}> {
+  return listCorpora({ formsOnly: true }).map((c) => ({
+    slug: c.slug,
+    formName: c.formName,
+    formDescription: c.formDescription ?? '',
+  }))
+}
+
 app.get('/new', (c) => {
   const user = c.get('user')
   if (!user) return c.redirect(resolveUrl('/auth/signin'))
@@ -338,6 +357,7 @@ app.get('/new', (c) => {
     <Layout currentPath="/new" user={user}>
       <NewProjectPage
         fixtures={demoFixtures}
+        corpora={getCorporaForPicker()}
         extractionVariant={extractionVariant}
       />
     </Layout>,
@@ -361,6 +381,7 @@ app.post('/new', async (c) => {
           <Layout currentPath="/new" user={user}>
             <NewProjectPage
               fixtures={demoFixtures}
+              corpora={getCorporaForPicker()}
               extractionVariant={extractionVariant}
             />
           </Layout>,
@@ -380,9 +401,27 @@ app.post('/new', async (c) => {
     const corpusId = String(body.corpus ?? '').trim()
 
     if (corpusId) {
-      // Corpus-only project (no PDF extraction)
-      const name = 'Wisconsin FoodShare SNAP Application'
-      const project = await projectService.createEmptyProject(name, user)
+      // Corpus-only project (no PDF extraction). Persist the corpus
+      // slug on the project so the authoring pipeline can retrieve
+      // from the right corpus downstream.
+      const corpusMetadata = getCorpusMetadata(corpusId)
+      if (!corpusMetadata || !corpusMetadata.formDescription) {
+        return c.html(
+          <Layout currentPath="/new" user={user}>
+            <NewProjectPage
+              fixtures={demoFixtures}
+              corpora={getCorporaForPicker()}
+              extractionVariant={extractionVariant}
+            />
+          </Layout>,
+          400,
+        )
+      }
+      const project = await projectService.createEmptyProject(
+        corpusMetadata.formName,
+        user,
+        { corpusSlug: corpusMetadata.slug },
+      )
       return c.redirect(
         resolveUrl(`/${user.login}/${project.slug}/edit/import`),
       )
@@ -396,6 +435,7 @@ app.post('/new', async (c) => {
         <Layout currentPath="/new" user={user}>
           <NewProjectPage
             fixtures={demoFixtures}
+            corpora={getCorporaForPicker()}
             extractionVariant={extractionVariant}
           />
         </Layout>,

--- a/src/services/projects/project-service.ts
+++ b/src/services/projects/project-service.ts
@@ -72,7 +72,11 @@ export interface ProjectService {
     pdf: Buffer,
     user: SessionUser,
   ): Promise<ProjectIndex>
-  createEmptyProject(name: string, user: SessionUser): Promise<ProjectIndex>
+  createEmptyProject(
+    name: string,
+    user: SessionUser,
+    options?: { corpusSlug?: string | null },
+  ): Promise<ProjectIndex>
   getProject(
     owner: string,
     slug: string,
@@ -385,6 +389,7 @@ export function createProjectService(
     async createEmptyProject(
       name: string,
       user: SessionUser,
+      options: { corpusSlug?: string | null } = {},
     ): Promise<ProjectIndex> {
       requireAuth(user)
 
@@ -393,6 +398,7 @@ export function createProjectService(
         name,
         slug,
         createdBy: user.login,
+        corpusSlug: options.corpusSlug ?? null,
       })
 
       try {

--- a/src/services/rag/corpus.ts
+++ b/src/services/rag/corpus.ts
@@ -21,6 +21,35 @@ interface Frontmatter {
   source: string
 }
 
+/**
+ * Metadata about an available policy corpus, surfaced to UI code
+ * that needs to let the user choose a corpus or display information
+ * about the corpus that grounds a project.
+ */
+export interface CorpusMetadata {
+  /** Stable slug used in URLs, project records, and retrieval queries. */
+  slug: string
+  /** Corpus display name (taken from `title` in frontmatter). */
+  title: string
+  /** Regulatory source citation (e.g. "7 CFR 273"). */
+  source: string
+  /**
+   * User-facing name of the form this corpus builds. May differ from
+   * `title` — `title` names the corpus ("Wisconsin SNAP Application
+   * Policy Excerpts"), `formName` names the resulting form
+   * ("Wisconsin FoodShare (SNAP) Application"). Falls back to `title`
+   * when absent.
+   */
+  formName: string
+  /**
+   * Plain-English description of the form this corpus supports.
+   * Surfaced on the project overview page and the new-project
+   * picker. Absent on corpora that have not yet opted into the
+   * authoring flow — those are extraction-only references.
+   */
+  formDescription: string | null
+}
+
 const CORPUS_FILES: Array<{ path: string }> = [
   { path: 'pardon-application.md' },
   { path: 'i-9.md' },
@@ -96,6 +125,63 @@ export interface LoadPolicyCorpusOptions {
   baseDir?: string
   /** Load corpus from project directory instead of catalog. */
   projectDir?: string
+}
+
+export interface ListCorporaOptions {
+  /** Override the base directory (tests, alternate layouts). */
+  baseDir?: string
+  /**
+   * When true, only return corpora that declare a `formDescription`
+   * in their frontmatter — i.e. corpora that have opted into the
+   * authoring flow. Extraction-only corpora (pardon, I-9, W-9) are
+   * omitted. Defaults to false so callers that need the full list
+   * (e.g. evaluation) still see every corpus.
+   */
+  formsOnly?: boolean
+}
+
+/**
+ * List every available policy corpus under catalog/references. Used
+ * by the new-project picker to render the "build from corpus" button
+ * set and by the project overview page to resolve a stored
+ * `corpusSlug` back to display metadata.
+ */
+export function listCorpora(
+  options: ListCorporaOptions = {},
+): CorpusMetadata[] {
+  const baseDir =
+    options.baseDir ?? join(process.cwd(), 'catalog', 'references')
+  const corpora: CorpusMetadata[] = []
+
+  for (const { path } of CORPUS_FILES) {
+    const fullPath = join(baseDir, path)
+    if (!existsSync(fullPath)) continue
+    const raw = readFileSync(fullPath, 'utf-8')
+    const { data } = parseFrontmatter(raw)
+    if (!data.formSlug) continue
+    const formDescription = data.formDescription ?? null
+    if (options.formsOnly && !formDescription) continue
+    corpora.push({
+      slug: data.formSlug,
+      title: data.title ?? data.formSlug,
+      source: data.source ?? '',
+      formName: data.formName ?? data.title ?? data.formSlug,
+      formDescription,
+    })
+  }
+
+  return corpora
+}
+
+/**
+ * Look up a single corpus by slug. Returns null when the slug does
+ * not match any known corpus.
+ */
+export function getCorpusMetadata(
+  slug: string,
+  options: ListCorporaOptions = {},
+): CorpusMetadata | null {
+  return listCorpora(options).find((c) => c.slug === slug) ?? null
 }
 
 export function loadPolicyCorpus(

--- a/src/services/rag/index.ts
+++ b/src/services/rag/index.ts
@@ -1,4 +1,11 @@
-export { type LoadPolicyCorpusOptions, loadPolicyCorpus } from './corpus'
+export {
+  type CorpusMetadata,
+  getCorpusMetadata,
+  type ListCorporaOptions,
+  type LoadPolicyCorpusOptions,
+  listCorpora,
+  loadPolicyCorpus,
+} from './corpus'
 export {
   cosineSimilarity,
   createHashEmbedder,

--- a/src/services/storage/sqlite-project-store.ts
+++ b/src/services/storage/sqlite-project-store.ts
@@ -17,6 +17,7 @@ export function createProjectStore(dbPath: string): ProjectStore {
       slug TEXT NOT NULL UNIQUE,
       name TEXT NOT NULL,
       forked_from TEXT,
+      corpus_slug TEXT,
       status TEXT NOT NULL DEFAULT 'extracting',
       error TEXT,
       created_by TEXT NOT NULL,
@@ -46,6 +47,7 @@ export function createProjectStore(dbPath: string): ProjectStore {
         slug TEXT NOT NULL UNIQUE,
         name TEXT NOT NULL,
         forked_from TEXT,
+        corpus_slug TEXT,
         status TEXT NOT NULL DEFAULT 'extracting',
         error TEXT,
         created_by TEXT NOT NULL,
@@ -54,6 +56,11 @@ export function createProjectStore(dbPath: string): ProjectStore {
       )
     `)
     console.log('Projects table recreated with current schema')
+  } else if (!columns.includes('corpus_slug')) {
+    // Forward-compatible migration: add corpus_slug to existing
+    // projects tables. Nullable so historical PDF-based rows stay
+    // valid.
+    db.run('ALTER TABLE projects ADD COLUMN corpus_slug TEXT')
   }
 
   function rowToProject(row: Record<string, unknown>): ProjectIndex {
@@ -62,6 +69,7 @@ export function createProjectStore(dbPath: string): ProjectStore {
       slug: row.slug as string,
       name: row.name as string,
       forkedFrom: (row.forked_from as string | null) ?? null,
+      corpusSlug: (row.corpus_slug as string | null) ?? null,
       status: row.status as ProjectStatus,
       error: (row.error as string | null) ?? null,
       createdBy: row.created_by as string,
@@ -75,13 +83,14 @@ export function createProjectStore(dbPath: string): ProjectStore {
       const id = crypto.randomUUID()
       const now = Math.floor(Date.now() / 1000)
       db.run(
-        `INSERT INTO projects (id, slug, name, forked_from, created_by, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO projects (id, slug, name, forked_from, corpus_slug, created_by, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
         [
           id,
           project.slug,
           project.name,
           project.forkedFrom ?? null,
+          project.corpusSlug ?? null,
           project.createdBy,
           now,
           now,

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -210,6 +210,15 @@ export interface ProjectIndex {
   slug: string
   name: string
   forkedFrom: string | null
+  /**
+   * Slug of the policy corpus this project was created from, when
+   * applicable. `null` for projects imported from a PDF (the
+   * extraction path). A non-null value means this project uses the
+   * RAG-authoring flow and retrieval queries should be keyed on this
+   * slug. Resolves against `listCorpora()` / `getCorpusMetadata()`
+   * in the RAG service.
+   */
+  corpusSlug: string | null
   status: ProjectStatus
   error: string | null
   createdBy: string
@@ -222,6 +231,8 @@ export interface NewProjectIndex {
   slug: string
   createdBy: string
   forkedFrom?: string
+  /** See ProjectIndex.corpusSlug. Optional; absent means PDF-based project. */
+  corpusSlug?: string | null
 }
 
 /**


### PR DESCRIPTION
Replaces the 9 hardcoded \`'snap-wisconsin'\` references in the authoring flow with a real data model. Each project now records which policy corpus it was created from; every downstream stage retrieves from that corpus instead of defaulting. **Adding a second corpus is now a data change, not a code change.**

## Data model

- RAG service gains \`listCorpora()\` and \`getCorpusMetadata(slug)\`. Reads frontmatter from \`catalog/references/*.md\`; exposes each corpus's slug, title, source, \`formName\`, and \`formDescription\`. A \`formsOnly\` flag lets the picker surface only corpora that have opted into authoring.
- SNAP Wisconsin corpus frontmatter gains \`formName\` and \`formDescription\`. Extraction-only corpora (pardon, I-9, W-9) remain without — they don't appear in the authoring picker.
- \`ProjectIndex\` gains a nullable \`corpusSlug\` column. SQLite store adds the column via \`ALTER TABLE\` on existing databases; new databases get it in the schema.
- \`ProjectService.createEmptyProject\` takes an \`options\` object that threads \`corpusSlug\` through to storage.

## Request flow

- \`POST /new\` (corpus-based path) looks up the corpus metadata, derives the project name from the corpus's \`formName\`, and persists the slug on the project.
- Every authoring handler that previously hardcoded \`loadPolicyCorpus({ slug: 'snap-wisconsin' })\` now reads the slug from \`view.project.corpusSlug\`. Handlers 400 when a project without a corpus tries to run authoring — the data model says this is an invariant violation, not a fallback case.
- The long-running \`runBuild\` resolves the slug once at the top and logs \`Corpus: <slug>\` in the progress stream.

## UI

- \`NewProjectPage\` iterates over \`getCorporaForPicker()\` for the "Create from policy corpus" section. Each button is generated from corpus frontmatter — form name as the card title, form description as the subtitle. No more hardcoded "Build from SNAP Policy Corpus" string.
- \`ProjectOverview\` accepts an optional \`corpus\` prop that surfaces a callout near the top: form name, slug, regulatory source, description. When the project has no corpus (PDF-based), nothing renders — the callout is purely additive.

## One intentional hardcoded slug left

\`src/entrypoints/cli/commands/evaluate-authoring.ts\` still loads \`snap-wisconsin\` because it compares against that specific ground-truth fixture. Every other site now reads from the project.

## Testing

- [x] \`bun run check\` — 1341 tests pass, link validator clean.
- [x] Smoke-tested the corpus registry in a bun -e — returns the 4 corpora from frontmatter, \`formsOnly: true\` returns only SNAP.