### PR TITLE
feat(authoring): per-stage retrieval against the project corpus

### DIFF
--- a/src/entrypoints/app/routes/owner/edit/authoring.tsx
+++ b/src/entrypoints/app/routes/owner/edit/authoring.tsx
@@ -19,9 +19,32 @@ import {
 } from '../../../../../services/form-authoring'
 import type { Command, ProjectState } from '../../../../../services/forms'
 import type { ProjectService } from '../../../../../services/projects'
-import { loadPolicyCorpus } from '../../../../../services/rag'
+import {
+  getCorpusMetadata,
+  retrieveOrFullCorpus,
+} from '../../../../../services/rag'
 import type { VariantPreferencesService } from '../../../../../services/variant-preferences'
 import { UnauthenticatedError } from '../../../../../shared/errors'
+
+/**
+ * Build a broad retrieval query for the planning stages (criteria
+ * analysis and structure generation). Uses the corpus's form name
+ * so the query is generic across corpora — for SNAP this becomes
+ * "Wisconsin FoodShare (SNAP) Application — eligibility, required
+ * information, application process, regulatory requirements."
+ */
+function planningQuery(corpusSlug: string): string {
+  const meta = getCorpusMetadata(corpusSlug)
+  const formName = meta?.formName ?? corpusSlug
+  return `${formName} — eligibility, required information, application process, regulatory requirements`
+}
+
+// Retrieval widths chosen to give the planning stages broad coverage
+// (criteria/structure need to see almost every policy topic to
+// produce a complete form) while narrowing section generation to
+// just the chunks closest to the group title.
+const PLANNING_K = 15
+const SECTION_K = 5
 
 const llmCache = new Map<string, unknown>()
 
@@ -146,8 +169,17 @@ export function createAuthoringRoutes(
 
       if (criteriaSet.criteria.length === 0) {
         log('Analyzing policy corpus...')
-        const corpus = loadPolicyCorpus({ slug: corpusSlug })
-        const criteriaList = await pipeline.analyzeCriteria(corpus)
+        const criteriaRetrieval = await retrieveOrFullCorpus(
+          corpusSlug,
+          planningQuery(corpusSlug),
+          PLANNING_K,
+        )
+        log(
+          `  criteria: ${criteriaRetrieval.source} (${criteriaRetrieval.chunks.length} chunks)`,
+        )
+        const criteriaList = await pipeline.analyzeCriteria(
+          criteriaRetrieval.chunks,
+        )
         criteriaSet = {
           criteria: criteriaList,
           approvedAt: null,
@@ -181,7 +213,15 @@ export function createAuthoringRoutes(
 
       // Step 3: Generate structure (pages only)
       log('Generating page structure (~20s)...')
-      const corpus = loadPolicyCorpus({ slug: corpusSlug })
+      const structureRetrieval = await retrieveOrFullCorpus(
+        corpusSlug,
+        planningQuery(corpusSlug),
+        PLANNING_K,
+      )
+      log(
+        `  structure: ${structureRetrieval.source} (${structureRetrieval.chunks.length} chunks)`,
+      )
+      const corpus = structureRetrieval.chunks
 
       const view = await service.getProject(owner, slug, user, branch)
       const state =
@@ -268,11 +308,23 @@ export function createAuthoringRoutes(
               explanation: string
             }
           } else {
+            // Per-section retrieval: the group title is the query;
+            // we expect a few nearest-neighbour chunks to cover the
+            // regulations relevant to the fields that section
+            // collects.
+            const sectionRetrieval = await retrieveOrFullCorpus(
+              corpusSlug,
+              group.title,
+              SECTION_K,
+            )
+            log(
+              `    [${group.title}] ${sectionRetrieval.source} (${sectionRetrieval.chunks.length} chunks)`,
+            )
             sectionResult = await pipeline.generateSection(
               group.id,
               group.title,
               criteriaSet.criteria,
-              corpus,
+              sectionRetrieval.chunks,
             )
             llmCache.set(cacheKey, sectionResult)
           }
@@ -397,7 +449,11 @@ export function createAuthoringRoutes(
           user,
           branch,
         )
-        const corpus = loadPolicyCorpus({ slug: corpusSlug })
+        const { chunks: corpus } = await retrieveOrFullCorpus(
+          corpusSlug,
+          planningQuery(corpusSlug),
+          PLANNING_K,
+        )
         const criteriaList = await pipeline.analyzeCriteria(corpus)
 
         const criteria: CriteriaSet = {
@@ -545,7 +601,11 @@ export function createAuthoringRoutes(
       if (!corpusSlug) {
         return c.json({ error: 'project has no associated policy corpus' }, 400)
       }
-      const corpus = loadPolicyCorpus({ slug: corpusSlug })
+      const { chunks: corpus } = await retrieveOrFullCorpus(
+        corpusSlug,
+        planningQuery(corpusSlug),
+        PLANNING_K,
+      )
 
       const state =
         view.formSpec && view.spec
@@ -617,7 +677,12 @@ export function createAuthoringRoutes(
             400,
           )
         }
-        const corpus = loadPolicyCorpus({ slug: view.project.corpusSlug })
+        // Per-section retrieval: the group title is the query.
+        const { chunks: corpus } = await retrieveOrFullCorpus(
+          view.project.corpusSlug,
+          body.groupTitle,
+          SECTION_K,
+        )
 
         const cacheKey = `section:${slug}:${branch}:${body.groupId}`
         if (llmCache.has(cacheKey)) {
@@ -684,7 +749,17 @@ export function createAuthoringRoutes(
             400,
           )
         }
-        const corpus = loadPolicyCorpus({ slug: view.project.corpusSlug })
+
+        // Resolve the group title so retrieval can use a natural-
+        // language query ("Household Composition") rather than the
+        // opaque group id.
+        const group = view.spec.groups.find((g) => g.id === body.groupId)
+        const query = group?.title ?? body.groupId
+        const { chunks: corpus } = await retrieveOrFullCorpus(
+          view.project.corpusSlug,
+          query,
+          SECTION_K,
+        )
 
         const state = {
           formSpec: view.formSpec as unknown as ProjectState['formSpec'],

--- a/src/services/rag/corpus-retriever.ts
+++ b/src/services/rag/corpus-retriever.ts
@@ -1,0 +1,126 @@
+/**
+ * Per-corpus retriever for authoring-stage RAG.
+ *
+ * Gives the authoring pipeline a real retrieval call per stage —
+ * criteria/structure get a broad top-k against a generic "what does
+ * this form need" query; section generation gets a focused top-k
+ * against the group title. All queries run through the same Titan
+ * embedder the extraction RAG uses.
+ *
+ * Memoized per slug: the first stage of a build pays the embedding
+ * cost (21 Titan calls for the SNAP corpus); subsequent stages (and
+ * subsequent builds on the same process) hit warm memory.
+ *
+ * Fallback behaviour: when Titan access is unavailable the hash
+ * embedder produces essentially random cosine scores for natural-
+ * language queries — worse than just sending the full corpus. So
+ * callers use `retrieveOrFullCorpus` which gracefully falls back to
+ * the pre-RAG "all chunks for this slug" path when semantic
+ * retrieval isn't available. This keeps the pipeline working when
+ * Titan is denied and confines the RAG claim to runs that actually
+ * did real retrieval.
+ */
+
+import {
+  createInMemoryRetriever,
+  createTitanEmbedder,
+  type Embedder,
+  loadPolicyCorpus,
+  type PolicyChunk,
+  type PolicyRetriever,
+} from '.'
+
+interface CorpusRetriever {
+  retriever: PolicyRetriever
+  embedderKind: 'titan'
+}
+
+// A per-slug promise that resolves to a working retriever or to
+// null. Both outcomes are memoized — we don't want to re-probe
+// Titan on every request.
+const memoBySlug = new Map<string, Promise<CorpusRetriever | null>>()
+
+async function tryTitan(): Promise<Embedder | null> {
+  if (process.env.RAG_EMBEDDER === 'hash') return null
+  const embedder = createTitanEmbedder()
+  try {
+    await embedder.embed('.')
+    return embedder
+  } catch (err) {
+    console.warn(
+      `[rag/authoring] Titan embedder unavailable; retrieval will fall back. Reason: ${String(
+        (err as Error).message ?? err,
+      )}`,
+    )
+    return null
+  }
+}
+
+/**
+ * Build or return a memoized retriever over the chunks of a single
+ * corpus. Returns `null` when semantic retrieval isn't available —
+ * callers should treat null as "fall back to full corpus." With
+ * hash embeddings, cosine scores on natural-language queries are
+ * essentially random, which is worse than just passing every chunk.
+ */
+export async function getCorpusRetriever(
+  slug: string,
+): Promise<CorpusRetriever | null> {
+  const existing = memoBySlug.get(slug)
+  if (existing) return existing
+
+  const promise = (async (): Promise<CorpusRetriever | null> => {
+    try {
+      const chunks = loadPolicyCorpus({ slug })
+      if (chunks.length === 0) return null
+
+      const titan = await tryTitan()
+      if (!titan) return null
+
+      const retriever = await createInMemoryRetriever(chunks, titan)
+      return { retriever, embedderKind: 'titan' }
+    } catch (err) {
+      console.warn(
+        `[rag/authoring] retriever bootstrap failed for ${slug}:`,
+        err,
+      )
+      return null
+    }
+  })()
+
+  memoBySlug.set(slug, promise)
+  return promise
+}
+
+/**
+ * Retrieve top-k chunks for a natural-language query against the
+ * named corpus. Falls back to the full corpus (all chunks for this
+ * slug) when semantic retrieval isn't available — preserving the
+ * pre-RAG behaviour rather than producing garbage retrievals.
+ *
+ * Returns the chunks and a tag describing how they were obtained so
+ * callers (or logs) can tell a real retrieval from a fallback.
+ */
+export async function retrieveOrFullCorpus(
+  slug: string,
+  query: string,
+  k: number,
+): Promise<{
+  chunks: PolicyChunk[]
+  source: 'retrieval' | 'full-corpus'
+}> {
+  const cached = await getCorpusRetriever(slug)
+  if (!cached) {
+    return { chunks: loadPolicyCorpus({ slug }), source: 'full-corpus' }
+  }
+  const chunks = await cached.retriever.retrieve(query, k)
+  if (chunks.length === 0) {
+    return { chunks: loadPolicyCorpus({ slug }), source: 'full-corpus' }
+  }
+  return { chunks, source: 'retrieval' }
+}
+
+/** Test seam. Do not call from production code. */
+export function resetCorpusRetrieverForTests(): void {
+  memoBySlug.clear()
+}

--- a/src/services/rag/index.ts
+++ b/src/services/rag/index.ts
@@ -7,6 +7,11 @@ export {
   loadPolicyCorpus,
 } from './corpus'
 export {
+  getCorpusRetriever,
+  resetCorpusRetrieverForTests,
+  retrieveOrFullCorpus,
+} from './corpus-retriever'
+export {
   cosineSimilarity,
   createHashEmbedder,
   createInMemoryRetriever,

--- a/test/services/rag/corpus-retriever.test.ts
+++ b/test/services/rag/corpus-retriever.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, test } from 'bun:test'
+import {
+  resetCorpusRetrieverForTests,
+  retrieveOrFullCorpus,
+} from '../../../src/services/rag'
+
+describe('retrieveOrFullCorpus', () => {
+  beforeEach(() => {
+    resetCorpusRetrieverForTests()
+    // Force the hash-path (no Titan probe) so the test is offline.
+    process.env.RAG_EMBEDDER = 'hash'
+  })
+
+  test('falls back to full corpus when semantic retrieval is disabled', async () => {
+    const result = await retrieveOrFullCorpus('snap-wisconsin', 'any query', 5)
+    expect(result.source).toBe('full-corpus')
+    // The SNAP corpus currently has 21 chunks; guard against off-by-a-few
+    // but assert we got the full set, not a top-k.
+    expect(result.chunks.length).toBeGreaterThan(15)
+    for (const chunk of result.chunks) {
+      expect(chunk.formSlug).toBe('snap-wisconsin')
+    }
+  })
+
+  test('returns an empty full-corpus result for an unknown slug', async () => {
+    const result = await retrieveOrFullCorpus('does-not-exist', 'q', 3)
+    expect(result.source).toBe('full-corpus')
+    expect(result.chunks).toEqual([])
+  })
+})


### PR DESCRIPTION
> Please leave unmerged. Opening for review so we have a concrete proposal on the table, not to ship today.

Turns the authoring pipeline's RAG from "corpus-grounded generation" into **retrieval per stage**. Every stage now issues a cosine-similarity query against a Titan-embedded index of the project's corpus chunks and sends only the top-k most relevant chunks to the LLM, instead of the full 21-chunk corpus.

## Why this matters

The earlier RAG ablation ([#104](https://github.com/flexion/forms-lab/pull/104) → [#105](https://github.com/flexion/forms-lab/pull/105)) established that the corpus is load-bearing — removing it drops authoring recall from 10.6 % to 4.7 %. But in the current code, every authoring LLM call receives the *full* 21-chunk corpus. That's "context-injection with a citation," not retrieval.

The catalog page [\`pdf-field-extraction/sonnet-with-rag\`](catalog/experiments/pdf-field-extraction/sonnet-with-rag.md) is honest about this: retrieval is real for extraction (slug query, top-2), and explicitly *not* real for authoring. This PR closes that gap.

## What it does

### New primitive: \`src/services/rag/corpus-retriever.ts\`

- \`getCorpusRetriever(slug)\` — per-slug memoized retriever. First call embeds the corpus chunks with Bedrock Titan; subsequent calls on the same process hit warm memory.
- \`retrieveOrFullCorpus(slug, query, k)\` — high-level wrapper. Returns top-k cosine-similar chunks when Titan is available; falls back to the full corpus when it isn't. Surfaces the source (\`retrieval\` vs \`full-corpus\`) so callers can log and the pipeline can honestly say whether this particular run did RAG.

**Hash-embedder fallback is deliberately disabled for authoring.** Unlike extraction (which queries by fixture slug, for which a deterministic hash works fine as a lookup), authoring queries are natural-language ("Household Composition"). The hash embedder produces essentially random cosine scores for these — worse than just passing every chunk. So we fall back to the full corpus when Titan is unavailable, and the pipeline stays correct.

### Rewired authoring routes

Every \`loadPolicyCorpus({ slug })\` call in \`src/entrypoints/app/routes/owner/edit/authoring.tsx\` — six sites — now calls \`retrieveOrFullCorpus(slug, query, k)\`.

Query construction:

| Stage | Query | k | Rationale |
|---|---|---|---|
| Criteria analysis | \`<formName> — eligibility, required information, application process, regulatory requirements\` | 15 | Broad coverage; criteria should reflect most of the policy surface |
| Structure planning | same | 15 | Structure needs to name every topical section the policy implies |
| Section generation | group title (e.g. "Household Composition") | 5 | Focused — fields in this section only need the chunks closest to its topic |
| Section evaluation | group title | 5 | Same |

For SNAP's 21-chunk corpus this means: planning stages see 15 of 21 chunks (cosine excludes the 6 least-relevant); section stages see 5.

### Visible log output

Each stage logs whether it retrieved or fell back. Sample progress stream for a build:

\`\`\`
Corpus: snap-wisconsin
  criteria: retrieval (15 chunks)
  structure: retrieval (15 chunks)
    [Applicant Information] retrieval (5 chunks)
    [Household Composition] retrieval (5 chunks)
    …
\`\`\`

## What this does NOT do

- **No benchmark re-run.** Re-running the SNAP ablation ([\`bun run cli evaluate authoring all-sonnet\`](src/entrypoints/cli/commands/evaluate-authoring.ts) and \`... no-rag-sonnet\`) against the new retrieval path requires Bedrock spend (~$0.30) and hasn't been done. Expected directional effect:
  - With-corpus (retrieval active): **possibly** similar or slightly lower recall than the 10.6 % we measured with full-corpus-per-call — if retrieval accidentally excludes a ground-truth-relevant chunk, fields go missing. Or slightly higher — if focus improves field quality per section.
  - Without-corpus: unchanged (4.7 %) — this path doesn't touch retrieval.
  - The ablation's *shape* — corpus matters — won't change.
- **No changes to the extraction RAG.** That already uses retrieval (different bootstrap, different fallback semantics appropriate for slug-keyed queries). Unifying the two primitives could come later.

## Risks worth reviewing

- **Hyperparameters are guesses.** k = 15 for planning and k = 5 for sections are defensible starting points, not optimized. If k is too low on planning, criteria / structure miss topics. If k is too low on sections, fields are regulation-thin.
- **Silent fallback.** If Titan access breaks in production, every call falls back to the full corpus and the pipeline keeps working — safe but easy to miss. The per-stage log helps; no monitoring/paging yet.
- **Memoization lives in module state.** One retriever per process per slug for process lifetime. For demo scale this is fine; for a real deployment the memory footprint grows with the number of corpora (21 × 1024-dim float vectors ≈ 86 KB per corpus, trivial).

## Testing

- [x] \`bun run check\` — 1354 tests pass (one new file; fallback semantics unit-tested).
- [ ] Benchmark re-run against SNAP ground truth.
- [ ] Manual smoke: build a SNAP form from \`/new\` and watch the progress stream for \`retrieval\` lines.