### PR TITLE
Set up Route53 hosted zone for forms.labs.flexion.us

### DIFF
--- a/infrastructure/nixos/configuration.nix
+++ b/infrastructure/nixos/configuration.nix
@@ -49,7 +49,8 @@
   users.groups.forms-lab = {};
 
   # Hostname — update after pulumi up provides the EC2 public DNS
-  flexion.hostname = "ec2-54-198-178-196.compute-1.amazonaws.com";
+  flexion.hostname = "forms.labs.flexion.us";
+  flexion.tlsMode = "acme";
 
   # Allow forms-lab user to manage its own services, reload Caddy, and
   # apply NixOS config changes that arrive via the webhook-driven main deploy.

--- a/infrastructure/pulumi/Pulumi.prod-marketing.yaml
+++ b/infrastructure/pulumi/Pulumi.prod-marketing.yaml
@@ -4,3 +4,4 @@ config:
   forms-lab:sshPublicKeyPath: /home/daniel/.ssh/id_ed25519.pub
   forms-lab:instanceType: t4g.medium
   forms-lab:amiId: ami-0b15df24682da2cd3
+  forms-lab:domain: forms.labs.flexion.us

--- a/infrastructure/pulumi/index.ts
+++ b/infrastructure/pulumi/index.ts
@@ -9,6 +9,7 @@ const sshPublicKey = readFileSync(resolve(sshKeyPath), 'utf-8').trim()
 
 const instanceType = config.get('instanceType') || 't3.medium'
 const amiId = config.require('amiId')
+const domain = config.get('domain')
 const nixosAmi = Promise.resolve({ id: amiId })
 
 // SSH key pair
@@ -155,8 +156,27 @@ const eip = new aws.ec2.Eip('forms-lab-eip', {
   },
 })
 
+// Route53 hosted zone (only when domain is configured)
+let zone: aws.route53.Zone | undefined
+if (domain) {
+	zone = new aws.route53.Zone('forms-lab-zone', {
+		name: domain,
+		tags: { Name: 'forms-lab' },
+	})
+
+	new aws.route53.Record('forms-lab-a', {
+		zoneId: zone.zoneId,
+		name: domain,
+		type: 'A',
+		ttl: 300,
+		records: [eip.publicIp],
+	})
+}
+
 // Outputs
 export const instanceId = instance.id
 export const publicIp = eip.publicIp
 export const hostname = eip.publicDns
 export const sshCommand = pulumi.interpolate`ssh root@${eip.publicDns}`
+export const nameServers = zone?.nameServers
+export const domainName = domain


### PR DESCRIPTION
## Context

Forms Lab is moving from an EC2 public hostname to a proper domain at `forms.labs.flexion.us`. The DNS architecture uses zone delegation: the `labs.flexion.us` apex zone lives in the AWS Main account, and individual service zones are delegated to the subaccount that runs them. This keeps day-to-day DNS management independent while the apex zone stays locked down.

## What this does

1. **Creates a Route53 hosted zone** for `forms.labs.flexion.us` in the Flexion Marketing AWS account, with an A record pointing to the existing Elastic IP (`54.198.178.196`).

2. **Switches Caddy** to serve on `forms.labs.flexion.us` with Let's Encrypt TLS instead of a self-signed certificate.

3. **Keeps it optional** — the `domain` config is only set on the `prod-marketing` stack. The `prod` stack is unaffected.

## What's needed to go live

The hosted zone is provisioned and the NixOS config is applied. Two things remain before the domain resolves:

- **NS delegation**: The four nameserver records below need to be added to the `labs.flexion.us` apex zone in the AWS Main account:
  ```
  ns-1334.awsdns-38.org
  ns-1923.awsdns-48.co.uk
  ns-326.awsdns-40.com
  ns-816.awsdns-38.net
  ```

- **GitHub OAuth callback**: Update the OAuth app's callback URL to `https://forms.labs.flexion.us/auth/callback` once DNS is live.

## Test plan

- [ ] `pulumi up` creates zone and A record without errors
- [ ] NS records are correct and ready for delegation
- [ ] After delegation, `dig forms.labs.flexion.us` resolves to `54.198.178.196`
- [ ] Caddy obtains a Let's Encrypt certificate automatically
- [ ] Site loads at `https://forms.labs.flexion.us` without certificate warnings
- [ ] GitHub OAuth sign-in works after callback URL update