### PR TITLE
infra(nixos): default flake target to aarch64 (Graviton)

### DIFF
--- a/infrastructure/nixos/flake.nix
+++ b/infrastructure/nixos/flake.nix
@@ -7,7 +7,7 @@
 
   outputs = { self, nixpkgs }:
   let
-    # Support both x86_64 (existing prod) and aarch64 (prod-marketing)
+    # Default is aarch64 (prod-marketing Graviton); x86 variant available
     mkSystem = system: nixpkgs.lib.nixosSystem {
       inherit system;
       modules = [
@@ -26,7 +26,7 @@
       ];
     };
   in {
-    nixosConfigurations.forms-lab = mkSystem "x86_64-linux";
-    nixosConfigurations.forms-lab-arm = mkSystem "aarch64-linux";
+    nixosConfigurations.forms-lab = mkSystem "aarch64-linux";
+    nixosConfigurations.forms-lab-x86 = mkSystem "x86_64-linux";
   };
 }

--- a/src/entrypoints/cli/commands/nixos.ts
+++ b/src/entrypoints/cli/commands/nixos.ts
@@ -8,7 +8,7 @@ function printUsage(): void {
   )
   console.log('Subcommands:')
   console.log(
-    '  apply [--from-branch <name>] [--arm]  Apply NixOS config via SSH',
+    '  apply [--from-branch <name>] [--x86]  Apply NixOS config via SSH',
   )
   console.log(
     '  status                        Show running services and health',
@@ -138,8 +138,8 @@ export async function nixos(args: string[]): Promise<number> {
       const safeBranch = branch.replace(/\//g, '-')
       const worktree = `/srv/forms-lab/${safeBranch}`
 
-      const isArm = args.includes('--arm')
-      const flakeTarget = isArm ? 'forms-lab-arm' : 'forms-lab'
+      const isX86 = args.includes('--x86')
+      const flakeTarget = isX86 ? 'forms-lab-x86' : 'forms-lab'
 
       console.log(
         `Applying NixOS config (${flakeTarget}) from ${worktree} on ${hostname}...`,


### PR DESCRIPTION
## Context

The prod-marketing EC2 instance is t4g.medium (ARM Graviton). The NixOS flake
defaulted to x86_64-linux, requiring `--arm` on every `nixos apply` invocation.
This caused a confusing cross-compilation error when the flag was forgotten.

## Changes

- Swap default `forms-lab` flake target from x86_64-linux to aarch64-linux
- Rename `forms-lab-arm` → `forms-lab-x86` for the legacy variant
- Replace `--arm` CLI flag with `--x86`

## Testing

- [x] `bun run check` passes (1354 tests, lint, type check)
- [x] `bun run cli nixos apply` verified on the live server (triggered the fix for the SSL issue)