### PR TITLE
docs: update demo URLs to forms.labs.flexion.us

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ step is a pluggable _variant_ that can be selected per user at runtime.
 
 ## Live demo
 
-- **Dashboard** — [https://ec2-54-198-178-196.compute-1.amazonaws.com/](https://ec2-54-198-178-196.compute-1.amazonaws.com/) (deployment overview, branch list)
-- **Application** — [https://ec2-54-198-178-196.compute-1.amazonaws.com/main/](https://ec2-54-198-178-196.compute-1.amazonaws.com/main/) (main branch)
-- **Catalog** — [https://ec2-54-198-178-196.compute-1.amazonaws.com/main/catalog](https://ec2-54-198-178-196.compute-1.amazonaws.com/main/catalog)
+- **Dashboard** — [https://forms.labs.flexion.us/](https://forms.labs.flexion.us/) (deployment overview, branch list)
+- **Application** — [https://forms.labs.flexion.us/main/](https://forms.labs.flexion.us/main/) (main branch)
+- **Catalog** — [https://forms.labs.flexion.us/main/catalog](https://forms.labs.flexion.us/main/catalog)
   (architecture, decisions, experiments, personas, stories, design system)
-- **Slide deck** — [https://ec2-54-198-178-196.compute-1.amazonaws.com/main/presentation](https://ec2-54-198-178-196.compute-1.amazonaws.com/main/presentation)
+- **Slide deck** — [https://forms.labs.flexion.us/main/presentation](https://forms.labs.flexion.us/main/presentation)
 
 Each active branch is deployed at `/<branch>/` alongside main.
 

--- a/catalog/stories/5-maya-reviews-her-proposed-changes-before-publishing.md
+++ b/catalog/stories/5-maya-reviews-her-proposed-changes-before-publishing.md
@@ -58,4 +58,4 @@ As a **form creator (Maya)**, in order to **understand the impact of my changes 
 - [x] Comparison and diff infrastructure works for DataCollectionSpec and FormSpec
 - [x] Tests pass (707 tests, 0 failures)
 - [x] Type checking passes
-- [x] Deployed and demoable at https://ec2-34-197-222-16.compute-1.amazonaws.com/story-5-review-changes/
+- [x] Deployed and demoable at https://forms.labs.flexion.us/story-5-review-changes/

--- a/scripts/test-main-deployment.ts
+++ b/scripts/test-main-deployment.ts
@@ -17,7 +17,7 @@
  * the checklist at the end.
  *
  * Usage:
- *   BASE_URL=https://ec2-34-197-222-16.compute-1.amazonaws.com bun run scripts/test-main-deployment.ts
+ *   BASE_URL=https://forms.labs.flexion.us bun run scripts/test-main-deployment.ts
  *
  * Exit 0 on success, 1 on any failure.
  */
@@ -28,7 +28,7 @@ const baseUrl = (process.env.BASE_URL ?? '').replace(/\/$/, '')
 if (!baseUrl) {
   console.error('ERROR: BASE_URL env var required')
   console.error(
-    '  Example: BASE_URL=https://ec2-34-197-222-16.compute-1.amazonaws.com bun run scripts/test-main-deployment.ts',
+    '  Example: BASE_URL=https://forms.labs.flexion.us bun run scripts/test-main-deployment.ts',
   )
   process.exit(1)
 }


### PR DESCRIPTION
## Summary
- Replace old EC2 hostnames (`ec2-54-198-178-196.compute-1.amazonaws.com`, `ec2-34-197-222-16.compute-1.amazonaws.com`) with `forms.labs.flexion.us` across README, test script, and story docs

## Files changed
- `README.md` — Live demo links
- `scripts/test-main-deployment.ts` — Example `BASE_URL` in comments
- `catalog/stories/5-maya-reviews-her-proposed-changes-before-publishing.md` — Deployment verification link

## Test plan
- [x] `bun run check` passes (lint, types, 1354 tests)