### PR TITLE
fix(security): harden deployed system before broader access

### DIFF
--- a/infrastructure/nixos/modules/caddy.nix
+++ b/infrastructure/nixos/modules/caddy.nix
@@ -23,6 +23,15 @@
         ${config.flexion.hostname} {
           ${if config.flexion.tlsMode == "internal" then "tls internal" else ""}
 
+          # Security headers
+          header {
+            Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
+            X-Content-Type-Options "nosniff"
+            X-Frame-Options "DENY"
+            Referrer-Policy "strict-origin-when-cross-origin"
+            Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' https://avatars.githubusercontent.com data:; font-src 'self'; connect-src 'self'; form-action 'self' https://github.com; base-uri 'self'; frame-ancestors 'none'"
+          }
+
           handle /.webhook* {
             uri strip_prefix /.webhook
             reverse_proxy localhost:9000

--- a/infrastructure/nixos/modules/deploy.nix
+++ b/infrastructure/nixos/modules/deploy.nix
@@ -195,7 +195,7 @@ BUILDEOF
     SESSION_SECRET=$(${pkgs.awscli2}/bin/aws secretsmanager get-secret-value \
       --secret-id "forms-lab/session-secret" --query 'SecretString' --output text --region us-east-1)
 
-    # Write per-branch env file
+    # Write per-branch env file (owner-only permissions to protect secrets)
     cat > "$BRANCH_DIR/.env" <<ENVEOF
 PORT=$PORT
 BASE_PATH=/$UNIT_NAME/
@@ -209,6 +209,7 @@ AWS_REGION=us-east-1
 CACHE_DB_PATH=/srv/forms-lab/cache.sqlite
 REPOS_PATH=/srv/forms-lab/repos
 ENVEOF
+    ${pkgs.coreutils}/bin/chmod 600 "$BRANCH_DIR/.env"
 
     # Start or restart the service (use full path to sudo wrapper with setuid bit)
     /run/wrappers/bin/sudo ${pkgs.systemd}/bin/systemctl restart "forms-lab-app@$UNIT_NAME.service" || \

--- a/src/entrypoints/app/routes/auth/index.ts
+++ b/src/entrypoints/app/routes/auth/index.ts
@@ -142,8 +142,11 @@ export function createAuthRoutes(userStore: UserStore): Hono {
       }
 
       if (emailMatchDomain) {
+        const domain = emailMatchDomain.slice(
+          emailMatchDomain.lastIndexOf('@') + 1,
+        )
         console.log(
-          `Authorized ${ghUser.login} via email domain match: ${emailMatchDomain}`,
+          `Authorized ${ghUser.login} via email domain match: @${domain}`,
         )
       }
 
@@ -165,6 +168,7 @@ export function createAuthRoutes(userStore: UserStore): Hono {
 
       setCookie(c, COOKIE_NAME, encryptedSession, {
         httpOnly: true,
+        secure: true,
         sameSite: 'Lax',
         maxAge: COOKIE_MAX_AGE,
         path: '/',

--- a/src/entrypoints/app/server.tsx
+++ b/src/entrypoints/app/server.tsx
@@ -452,7 +452,9 @@ app.post('/new', async (c) => {
       <Layout currentPath="/new" user={user}>
         <div class="flex-alert flex-alert--error" role="alert">
           <h2>Error creating project</h2>
-          <p>{err instanceof Error ? err.message : 'Unknown error occurred'}</p>
+          <p>
+            Something went wrong while creating the project. Please try again.
+          </p>
           <p>
             <a href={resolveUrl('/new')}>Try again</a>
           </p>

--- a/test/auth-routes.test.ts
+++ b/test/auth-routes.test.ts
@@ -121,6 +121,7 @@ describe('Auth Routes', () => {
       const cookie = res.headers.get('Set-Cookie')
       expect(cookie).toContain(COOKIE_NAME)
       expect(cookie).toContain('HttpOnly')
+      expect(cookie).toContain('Secure')
       expect(cookie).toContain('SameSite=Lax')
 
       // Verify user was persisted


### PR DESCRIPTION
## Summary

- Security audit covering auth, sessions, TLS/headers, network, IAM, secrets, error handling, and dependencies
- Added HTTP security headers (HSTS, CSP, X-Content-Type-Options, X-Frame-Options, Referrer-Policy) to Caddy
- Hardened session cookie (secure flag), error responses (generic messages), .env permissions (600), and auth logs (no PII)

## Story

Closes #114

## Acceptance Criteria

- [x] Each area has been reviewed and findings documented (`notes/story-114-audit-harden/findings.md`)
- [x] Critical and high-severity findings are resolved before the URL is shared
- [x] Medium and low findings are tracked as separate issues (#126, #127, #128)
- [x] A brief security summary is available for stakeholders (`notes/story-114-audit-harden/security-summary.md`)

## Test Plan

- [x] `bun run check` passes (pre-existing warnings only)
- [x] Auth route tests pass with new `Secure` cookie assertion
- [ ] Deploy to EC2 and verify security headers with `curl -I https://forms.labs.flexion.us`
- [ ] Verify login flow works end-to-end after cookie changes

## Review Notes

- CSP includes `'unsafe-inline'` for `script-src` because the codebase uses inline `onclick`/`onsubmit` handlers in several components. A follow-up to migrate these to external scripts would allow tightening the CSP.
- `secure: true` on the session cookie works on localhost in Chromium (which exempts localhost from the Secure requirement). Non-Chromium local dev may need `http://localhost` exemption if issues arise.
- SSH restriction (#126) deferred because it requires knowing the team's IP ranges.
- Full findings with severity ratings in `notes/story-114-audit-harden/findings.md`.