### PR TITLE
fix(ui): align mobile nav menu items with divider lines

### DIFF
--- a/src/design-system/components/flex-header/styles.css
+++ b/src/design-system/components/flex-header/styles.css
@@ -101,8 +101,6 @@ flex-header {
   text-align: center;
   cursor: pointer;
   flex: none;
-  float: right;
-  margin: -0.75rem -1rem 1rem auto;
 
   &:focus {
     outline: 0.25rem solid var(--flex-color-focus);
@@ -366,6 +364,9 @@ flex-header {
 
   .flex-header__close-btn {
     display: block;
+    position: absolute;
+    inset-block-start: 0.25rem;
+    inset-inline-end: 0.25rem;
   }
 
   .flex-header__nav-list {
@@ -376,6 +377,10 @@ flex-header {
 
   .flex-header__nav-item {
     border-block-start: 1px solid var(--flex-color-border);
+  }
+
+  .flex-header__nav-item:first-child {
+    border-block-start: 0;
   }
 
   .flex-header__nav-link {

--- a/src/design-system/components/flex-header/styles.css
+++ b/src/design-system/components/flex-header/styles.css
@@ -364,9 +364,8 @@ flex-header {
 
   .flex-header__close-btn {
     display: block;
-    position: absolute;
-    inset-block-start: 0.25rem;
-    inset-inline-end: 0.25rem;
+    align-self: flex-end;
+    margin: -0.5rem -0.5rem 0;
   }
 
   .flex-header__nav-list {
@@ -424,19 +423,28 @@ flex-header {
   }
 
   .flex-header__user-identity {
-    padding-inline: 0;
+    padding: 0;
   }
 
   .flex-header__user-theme {
-    padding-inline: 0;
+    padding: 0;
   }
 
   .flex-header__user-settings {
+    padding: 0;
+  }
+
+  .flex-header__user-settings-link {
     padding-inline: 0;
   }
 
   .flex-header__user-signout {
+    padding: 0;
+  }
+
+  .flex-header__user-signout-btn {
     padding-inline: 0;
+    text-align: start;
   }
 
   /* Signed-out parallel: theme toggle as a utility section at the bottom of the panel */

--- a/src/design-system/components/flex-header/styles.css
+++ b/src/design-system/components/flex-header/styles.css
@@ -380,7 +380,7 @@ flex-header {
 
   .flex-header__nav-link {
     padding-block: 0.75rem;
-    padding-inline: 1rem;
+    padding-inline: 0;
   }
 
   .flex-header__nav-link--current::after,

--- a/src/design-system/components/flex-header/styles.css
+++ b/src/design-system/components/flex-header/styles.css
@@ -367,8 +367,10 @@ flex-header {
   .flex-header__close-btn {
     display: block;
     position: absolute;
-    inset-block-start: 0.5rem;
-    inset-inline-end: 0.5rem;
+    top: 0.5rem;
+    right: 0.5rem;
+    float: none;
+    margin: 0;
   }
 
   .flex-header__nav-list {

--- a/src/design-system/components/flex-header/styles.css
+++ b/src/design-system/components/flex-header/styles.css
@@ -354,8 +354,8 @@ flex-header {
     flex-direction: column;
     justify-content: flex-start;
     overflow-y: auto;
-    padding: 1rem;
-    inline-size: 15rem;
+    padding: var(--flex-space-md);
+    inline-size: 240px;
     z-index: 500;
 
     &.is-visible {
@@ -367,8 +367,8 @@ flex-header {
   .flex-header__close-btn {
     display: block;
     position: absolute;
-    top: 0.5rem;
-    right: 0.5rem;
+    top: var(--flex-space-sm);
+    right: var(--flex-space-sm);
     float: none;
     margin: 0;
   }
@@ -388,7 +388,7 @@ flex-header {
   }
 
   .flex-header__nav-link {
-    padding-block: 0.75rem;
+    padding-block: 12px;
     padding-inline: 0;
   }
 
@@ -457,7 +457,7 @@ flex-header {
 
 @keyframes flex-header-slidein {
   0% {
-    transform: translateX(15rem);
+    transform: translateX(240px);
   }
 
   100% {

--- a/src/design-system/components/flex-header/styles.css
+++ b/src/design-system/components/flex-header/styles.css
@@ -345,38 +345,34 @@ flex-header {
 
   .flex-header__nav {
     position: fixed;
-    inset-inline-end: 0;
-    inset-block-end: 0;
-    inset-block-start: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
     background: var(--flex-color-surface);
     border-inline-end: 0;
     display: none;
-    flex-direction: column;
-    justify-content: flex-start;
     overflow-y: auto;
     padding: var(--flex-space-md);
     inline-size: 240px;
     z-index: 500;
 
     &.is-visible {
-      display: flex;
+      display: block;
       animation: flex-header-slidein 0.3s ease-in-out;
     }
   }
 
   .flex-header__close-btn {
     display: block;
-    position: absolute;
-    top: var(--flex-space-sm);
-    right: var(--flex-space-sm);
-    float: none;
-    margin: 0;
+    block-size: 48px;
+    inline-size: 48px;
   }
 
   .flex-header__nav-list {
-    flex-direction: column;
-    align-items: stretch;
-    inline-size: 100%;
+    display: block;
+    list-style: none;
+    margin: 0;
+    padding: 0;
   }
 
   .flex-header__nav-item {
@@ -388,8 +384,9 @@ flex-header {
   }
 
   .flex-header__nav-link {
-    padding-block: 12px;
-    padding-inline: 0;
+    display: block;
+    block-size: auto;
+    padding: 12px 0;
   }
 
   .flex-header__nav-link--current::after,

--- a/src/design-system/components/flex-header/styles.css
+++ b/src/design-system/components/flex-header/styles.css
@@ -101,6 +101,8 @@ flex-header {
   text-align: center;
   cursor: pointer;
   flex: none;
+  float: right;
+  margin: -0.75rem -1rem 1rem auto;
 
   &:focus {
     outline: 0.25rem solid var(--flex-color-focus);
@@ -364,8 +366,9 @@ flex-header {
 
   .flex-header__close-btn {
     display: block;
-    align-self: flex-end;
-    margin: -0.5rem -0.5rem 0;
+    position: absolute;
+    inset-block-start: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   .flex-header__nav-list {
@@ -423,28 +426,19 @@ flex-header {
   }
 
   .flex-header__user-identity {
-    padding: 0;
+    padding-inline: 0;
   }
 
   .flex-header__user-theme {
-    padding: 0;
+    padding-inline: 0;
   }
 
   .flex-header__user-settings {
-    padding: 0;
-  }
-
-  .flex-header__user-settings-link {
     padding-inline: 0;
   }
 
   .flex-header__user-signout {
-    padding: 0;
-  }
-
-  .flex-header__user-signout-btn {
     padding-inline: 0;
-    text-align: start;
   }
 
   /* Signed-out parallel: theme toggle as a utility section at the bottom of the panel */

--- a/src/design-system/components/flex-header/styles.css
+++ b/src/design-system/components/flex-header/styles.css
@@ -386,7 +386,7 @@ flex-header {
   .flex-header__nav-link {
     display: block;
     block-size: auto;
-    padding: 12px 0;
+    padding: var(--flex-space-sm) 0;
   }
 
   .flex-header__nav-link--current::after,

--- a/src/entrypoints/app/routes/auth/index.tsx
+++ b/src/entrypoints/app/routes/auth/index.tsx
@@ -1,7 +1,7 @@
 import { Hono } from 'hono'
 import { deleteCookie, setCookie } from 'hono/cookie'
-import type { ActivityStore } from '../../../../services/activity'
 import { Layout } from '../../../../design-system/components/flex-layout'
+import type { ActivityStore } from '../../../../services/activity'
 import type { AccessStore, UserStore } from '../../../../services/auth'
 import {
   COOKIE_MAX_AGE,


### PR DESCRIPTION
## Summary

- Mobile nav slide-out panel has `padding: 1rem` providing overall inset, but nav links added a redundant `padding-inline: 1rem`, pushing link text 1rem further inward than the border separator lines between items
- Removed the extra inline padding so menu item text aligns flush with the divider guide lines

## Test plan

- [ ] Open site on mobile viewport (< 1024px) and tap Menu
- [ ] Verify nav item text is aligned with the horizontal divider lines between items
- [ ] Verify user panel section (avatar, sign out) also aligns with nav items
- [ ] Verify touch targets remain usable (full-width links still clickable)