### PR TITLE
fix(ui): clean up projects page

### DIFF
--- a/src/entrypoints/app/routes/projects.tsx
+++ b/src/entrypoints/app/routes/projects.tsx
@@ -1,5 +1,4 @@
 import type { Context } from 'hono'
-import { Breadcrumb } from '../../../design-system/components/flex-breadcrumb/index'
 import { Layout } from '../../../design-system/components/flex-layout/index'
 import type { ProjectService } from '../../../services/projects'
 import { resolveUrl } from '../../../shared/base-path'
@@ -12,9 +11,15 @@ export function projectsDirectoryHandler(projectService: ProjectService) {
       .filter((p) => p.status === 'ready')
     return c.html(
       <Layout user={user} title="Projects" currentSection="projects">
-        <Breadcrumb items={[{ label: 'Projects' }]} />
         <div class="flex-form" data-size="large">
-          <h1>Projects</h1>
+          <div class="l-cluster justify-between" style="align-items: baseline;">
+            <h1>Projects</h1>
+            {user && (
+              <a href={resolveUrl('/new')} class="flex-button">
+                New Project
+              </a>
+            )}
+          </div>
           {projects.length === 0 ? (
             <p>No projects yet.</p>
           ) : (

--- a/test/projects/directory-route.test.ts
+++ b/test/projects/directory-route.test.ts
@@ -180,13 +180,22 @@ describe('GET /projects — projects directory route', () => {
     expect(html).toContain('Projects | Forms Lab')
   })
 
-  it('renders breadcrumb with "Projects" label', async () => {
+  it('shows New Project button for logged-in users', async () => {
     const { service } = makeService()
     const app = createTestApp(service)
 
     const res = await app.request('/projects')
     const html = await res.text()
-    expect(html).toContain('flex-breadcrumb')
-    expect(html).toContain('Projects')
+    expect(html).toContain('New Project')
+    expect(html).toContain('/new')
+  })
+
+  it('hides New Project button for anonymous users', async () => {
+    const { service } = makeService()
+    const app = createTestApp(service, null)
+
+    const res = await app.request('/projects')
+    const html = await res.text()
+    expect(html).not.toContain('New Project')
   })
 })


### PR DESCRIPTION
## Summary
- Removed redundant breadcrumb that displayed "Projects" directly above the `<h1>Projects</h1>` heading
- Added a "New Project" button for logged-in users, consistent with the owner profile and dashboard pages

## Test plan
- [ ] Visit `/projects` while logged out — no "New Project" button visible
- [ ] Visit `/projects` while logged in — "New Project" button appears, links to `/new`
- [ ] Confirm only one "Projects" heading (no breadcrumb duplication)